### PR TITLE
Remove :start from tomcat service definition.  Resolves COOK-1599.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,7 +42,7 @@ service "tomcat" do
   when "debian","ubuntu"
     supports :restart => true, :reload => true, :status => true
   end
-  action [:enable, :start]
+  action [:enable]
 end
 
 case node["platform"]


### PR DESCRIPTION
On EL6 systems, if the service is still starting when it receives a request to
restart, the restart will fail.  This was first noticed using a vagrant Centos
6.3 system.  Removing :start alleviates the problem.
