### PR TITLE
COOK-1736 add authbind attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,6 +21,7 @@ default["tomcat"]["ssl_port"] = 8443
 default["tomcat"]["ajp_port"] = 8009
 default["tomcat"]["java_options"] = "-Xmx128M -Djava.awt.headless=true"
 default["tomcat"]["use_security_manager"] = false
+default["tomcat"]["authbind"] = "no"
 
 case platform
 when "centos","redhat","fedora"

--- a/templates/default/default_tomcat6.erb
+++ b/templates/default/default_tomcat6.erb
@@ -61,4 +61,4 @@ JVM_TMP=<%= node["tomcat"]["tmp_dir"] %>
 # do not need authbind.  It is used for binding Tomcat to lower port numbers.
 # NOTE: authbind works only with IPv4.  Do not enable it when using IPv6.
 # (yes/no, default: no)
-#AUTHBIND=no
+AUTHBIND=<%= node["tomcat"]["authbind"] %>


### PR DESCRIPTION
With an AUTHBIND attribute you can easily allow Tomcat to use Authbind to bind to privileged ports like 80.
