### PR TITLE
Allow customizing which IP address(es) Tomcat binds to.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,8 +16,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+default["tomcat"]["host"] = '*'
 default["tomcat"]["port"] = 8080
+default["tomcat"]["ssl_host"] = '*'
 default["tomcat"]["ssl_port"] = 8443
+default["tomcat"]["ajp_host"] = '*'
 default["tomcat"]["ajp_port"] = 8009
 default["tomcat"]["java_options"] = "-Xmx128M -Djava.awt.headless=true"
 default["tomcat"]["use_security_manager"] = false

--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -73,6 +73,7 @@
          Define a non-SSL HTTP/1.1 Connector on port <%= node["tomcat"]["port"] %>
     -->
     <Connector port="<%= node["tomcat"]["port"] %>" protocol="HTTP/1.1" 
+               address="<%= node["tomcat"]["host"] %>"
                connectionTimeout="20000" 
                URIEncoding="UTF-8"
                redirectPort="<%= node["tomcat"]["ssl_port"] %>" />
@@ -88,13 +89,14 @@
          connector should be using the OpenSSL style configuration
          described in the APR documentation -->
     <!--
-    <Connector port="<%= node["tomcat"]["ssl_port"] %>" protocol="HTTP/1.1" SSLEnabled="true"
+    <Connector port="<%= node["tomcat"]["ssl_port"] %>" protocol="HTTP/1.1"
+               address="<%= node["tomcat"]["ssl_host"] %>" SSLEnabled="true"
                maxThreads="150" scheme="https" secure="true"
                clientAuth="false" sslProtocol="TLS" />
     -->
 
     <!-- Define an AJP 1.3 Connector on port <%= node["tomcat"]["ajp_port"] %> -->
-    <Connector port="<%= node["tomcat"]["ajp_port"] %>" protocol="AJP/1.3" redirectPort="<%= node["tomcat"]["ssl_port"] %>" />
+    <Connector port="<%= node["tomcat"]["ajp_port"] %>" protocol="AJP/1.3" address="<%= node["tomcat"]["ajp_host"] %>" redirectPort="<%= node["tomcat"]["ssl_port"] %>" />
 
 
     <!-- An Engine represents the entry point (within Catalina) that processes


### PR DESCRIPTION
You might do this if you want Tomcat to listen only on localhost,
for example.