### PR TITLE
[COOK-2695] Allow use of oracle java as default version on ubuntu

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,10 @@
 # limitations under the License.
 #
 
-include_recipe "java"
+# [COOK-2695]
+if node[:java][:install_flavor] == 'openjdk'
+  include_recipe 'java'
+end
 
 tomcat_pkgs = value_for_platform(
   ["debian","ubuntu"] => {
@@ -78,4 +81,9 @@ template "/etc/tomcat6/logging.properties" do
   group "root"
   mode "0644"
   notifies :restart, "service[tomcat]"
+end
+
+# [COOK-2695]
+if node[:java][:install_flavor] == 'oracle'
+  include_recipe 'java'
 end


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-2695

If you dont wish to use openjdk as your default java version this is currently not possible as apt-get install tomcat6 includes an installation of openjdk-6-jdk.

Since the java cookbook is included before tomcat it will be overridden due to this.

See [ticket](http://tickets.opscode.com/browse/COOK-2695)