### PR TITLE
[COOK-3203] Disable reload on Debian/Ubuntu as it is not supported.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.14.3:
+
+### Bug
+
+- [COOK-3203]: Tomcat init script on Ubuntu does not support
+  `reload` argument.
+
 ## v0.14.2:
 
 ### Bug

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -65,7 +65,7 @@ service "tomcat" do
   when "centos","redhat","fedora"
     supports :restart => true, :status => true
   when "debian","ubuntu"
-    supports :restart => true, :reload => true, :status => true
+    supports :restart => true, :reload => false, :status => true
   end
   action [:enable, :start]
 end


### PR DESCRIPTION
This patch has been tested in my environment. It should be noted that the supported 'reload' option for the tomcat init script is 'force-reload' which just does a stop and start, and is the same behavior as Chef doing a restart.
