### PR TITLE
[COOK-3204] Use attribute path of config_dir opposed to hard-coded path ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.14.3:
+
+### Bug
+
+- [COOK-3204]: Replace hard-coded path with config_dir
+  attribute.
+
 ## v0.14.2:
 
 ### Bug

--- a/recipes/users.rb
+++ b/recipes/users.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-template "/etc/tomcat6/tomcat-users.xml" do
+template "#{node["tomcat"]["config_dir"]}/tomcat-users.xml" do
   source "tomcat-users.xml.erb"
   owner "root"
   group "root"


### PR DESCRIPTION
...in users.rb recipe.

Tested on Ubuntu 12.04.
