### PR TITLE
[COOK-1599] Add retry and delay to tomcat service definition

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -68,6 +68,8 @@ service "tomcat" do
     supports :restart => true, :reload => false, :status => true
   end
   action [:enable, :start]
+  retries 4
+  retry_delay 30
 end
 
 node.set_unless['tomcat']['keystore_password'] = secure_password


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-1599

On el6 and some other systems, the init script to start tomcat returns
immediately, but the service can take several seconds to initialize.  When the
restart from writing configuration files comes, the tomcat service will not
respond to it properly. It returns an error that causes the recipe to fail.
The retry delay is set longer than we need for an empty tomcat server, but is
intended to avoid problems when you have a tomcat app installed that takes
longer to start.
