### PR TITLE
[COOK-3378] Actually use the keystore in the port 8443 connector

### DIFF
--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -97,6 +97,9 @@
              <% if node["tomcat"].has_key?("ssl_proxy_port") -%>
                proxyPort="<%= node["tomcat"]["ssl_proxy_port"] %>"
              <% end -%>
+               keystoreFile="<%= node["tomcat"]["config_dir"] %>/<%= node["tomcat"]["keystore_file"] %>"
+               keystorePass="<%= node["tomcat"]["keystore_password"] %>"
+               keystoreType="<%= node["tomcat"]["keystore_type"] %>"
                maxThreads="150" scheme="https" secure="true"
                clientAuth="false" sslProtocol="TLS" />
   <% end -%>


### PR DESCRIPTION
My patch enabling SSL support (COOK-2425) correctly generated a keystore, but then failed to actually refer to it in the SSL connector in server.xml. This patch corrects that oversight.

See http://tickets.opscode.com/browse/COOK-3378
