### PR TITLE
Tomcat 7 and issue with jvm options

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -67,7 +67,7 @@ when "debian","ubuntu"
   default["tomcat"]["tmp_dir"] = "/tmp/tomcat#{node["tomcat"]["base_version"]}-tmp"
   default["tomcat"]["work_dir"] = "/var/cache/tomcat#{node["tomcat"]["base_version"]}"
   default["tomcat"]["context_dir"] = "#{node["tomcat"]["config_dir"]}/Catalina/localhost"
-  default["tomcat"]["webapp_dir"] = "/var/lib/#{node["tomcat"]["base_version"]}/webapps"
+  default["tomcat"]["webapp_dir"] = "/var/lib/tomcat#{node["tomcat"]["base_version"]}/webapps"
   default["tomcat"]["keytool"] = "/usr/lib/jvm/default-java/bin/keytool"
   default["tomcat"]["endorsed_dir"] = "#{node["tomcat"]["home"]}/lib/endorsed"
 else

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,6 +42,7 @@ default["tomcat"]["truststore_type"] = "jks"
 default["tomcat"]["certificate_dn"] = "cn=localhost"
 default["tomcat"]["loglevel"] = "INFO"
 default["tomcat"]["tomcat_auth"] = "true"
+default["tomcat"]["gzip_enabled"] = true
 
 case node['platform']
 when "centos","redhat","fedora"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -67,7 +67,7 @@ when "debian","ubuntu"
   default["tomcat"]["tmp_dir"] = "/tmp/tomcat#{node["tomcat"]["base_version"]}-tmp"
   default["tomcat"]["work_dir"] = "/var/cache/tomcat#{node["tomcat"]["base_version"]}"
   default["tomcat"]["context_dir"] = "#{node["tomcat"]["config_dir"]}/Catalina/localhost"
-  default["tomcat"]["webapp_dir"] = "/var/lib/#{tomcat}/webapps"
+  default["tomcat"]["webapp_dir"] = "/var/lib/#{node["tomcat"]["base_version"]}/webapps"
   default["tomcat"]["keytool"] = "/usr/lib/jvm/default-java/bin/keytool"
   default["tomcat"]["endorsed_dir"] = "#{node["tomcat"]["home"]}/lib/endorsed"
 else

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -67,7 +67,7 @@ when "debian","ubuntu"
   default["tomcat"]["tmp_dir"] = "/tmp/tomcat#{node["tomcat"]["base_version"]}-tmp"
   default["tomcat"]["work_dir"] = "/var/cache/tomcat#{node["tomcat"]["base_version"]}"
   default["tomcat"]["context_dir"] = "#{node["tomcat"]["config_dir"]}/Catalina/localhost"
-  default["tomcat"]["webapp_dir"] = "/var/lib/#{tomcatN}/webapps"
+  default["tomcat"]["webapp_dir"] = "/var/lib/#{tomcat}/webapps"
   default["tomcat"]["keytool"] = "/usr/lib/jvm/default-java/bin/keytool"
   default["tomcat"]["endorsed_dir"] = "#{node["tomcat"]["home"]}/lib/endorsed"
 else

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -108,7 +108,7 @@ template "#{node["tomcat"]["config_dir"]}/server.xml" do
   notifies :restart, "service[tomcat]"
 end
 
-template "/etc/tomcat6/logging.properties" do
+template "/etc/tomcat#{node["tomcat"]["base_version"]}/logging.properties" do
   source "logging.properties.erb"
   owner "root"
   group "root"

--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -80,7 +80,14 @@
              <% if node["tomcat"].has_key?("proxy_port") -%>
                proxyPort="<%= node["tomcat"]["proxy_port"] %>"
              <% end -%>
-               redirectPort="<%= node["tomcat"]["ssl_port"] %>" />
+               redirectPort="<%= node["tomcat"]["ssl_port"] %>" 
+             <% if node["tomcat"]["gzip_enabled"] -%>
+               compression="on" 
+               compressionMinSize="2048" 
+               noCompressionUserAgents="gozilla, traviata" 
+               compressableMimeType="text/html,text/xml,application/json"
+              <% end -%>
+               />
     <!-- A "Connector" using the shared thread pool-->
     <!--
     <Connector executor="tomcatThreadPool"


### PR DESCRIPTION
Hey,

This pull request fixes a couple of things:
* typos in  b0d0nne11's pull request that added tomcat7 support. Some variables are names "tomcatN" or still referenced the (non existing) tomcat6 installation folders.
* fixes an issue where setting invalid JVM options would put tomcat in an unrestartable state, effectively causing every subsequent chef run to fail, unless a manual change is made to tomcat's default file.

to reproduce this issue:
1. update node's node["tomcat"]["java_options"] to have invalid options. In my case, enabling JMX remote port without updating the default jmx password file permissions (/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/management/jmxremote.password), nor disabling authentication. This will cause tomcat to fail to start due to loose permissions on the password file.
2. update the node's tomcat java_options to now have valid options and sudo chef-client
3. the recipe tries to start tomcat before setting the new default JVM options. Since the options are invalid, tomcat fails to start and causes the chef run to abort with an exception. The only way out at this point is to manually update /etc/default/tomcat7 (ubuntu 12.04) and rerun chef with the valid options.

The fix is simply to start the service after all templates have been created.

As a cherry on top, I've added gzip support to tomcat's server.xml