### PR TITLE
- added "amazon" as platform

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -45,7 +45,7 @@ default["tomcat"]["loglevel"] = "INFO"
 default["tomcat"]["tomcat_auth"] = "true"
 
 case node['platform']
-when "centos","redhat","fedora"
+when "centos","redhat","fedora","amazon"
   default["tomcat"]["user"] = "tomcat"
   default["tomcat"]["group"] = "tomcat"
   default["tomcat"]["home"] = "/usr/share/tomcat#{node["tomcat"]["base_version"]}"


### PR DESCRIPTION
added "amazon" as a platform for AWS Opsworks users who use Amazon Linux as a platform.
