### PR TITLE
refactoring tomcat_users to an attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,6 +43,7 @@ default["tomcat"]["truststore_type"] = "jks"
 default["tomcat"]["certificate_dn"] = "cn=localhost"
 default["tomcat"]["loglevel"] = "INFO"
 default["tomcat"]["tomcat_auth"] = "true"
+default["tomcat"]["users_databag"] = "tomcat_users"
 
 case node['platform']
 when "centos","redhat","fedora","amazon"

--- a/libraries/chef_tomcat_cookbook.rb
+++ b/libraries/chef_tomcat_cookbook.rb
@@ -41,7 +41,7 @@ class Chef
       end
     end
 
-    USERS_DATA_BAG = "tomcat_users"
+    USERS_DATA_BAG = node["tomcat"]["users_databag"]
 
     class << self
       # Returns a array of data bag items for the users in the Tomcat Users


### PR DESCRIPTION
Having the name of the tomcat_users data bag as an attribute allows for more flexibility in granting access to groups of users.
