### PR TITLE
SSL Disable/Enable and Auto Start/Restart Disable/Enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Attributes
 * `node["tomcat"]["base_version"]` - The version of tomcat to install, default `6`.
 * `node["tomcat"]["port"]` - The network port used by Tomcat's HTTP connector, default `8080`.
 * `node["tomcat"]["proxy_port"]` - if set, the network port used by Tomcat's Proxy HTTP connector, default nil.
+* `node["tomcat"]["ssl_enable"]` - if set to false, skip SSL configuration, default `true`.
 * `node["tomcat"]["ssl_port"]` - The network port used by Tomcat's SSL HTTP connector, default `8443`.
 * `node["tomcat"]["ssl_proxy_port"]` - if set, the network port used by Tomcat's Proxy SSL HTTP connector, default nil.
 * `node["tomcat"]["ajp_port"]` - The network port used by Tomcat's AJP connector, default `8009`.
@@ -29,6 +30,7 @@ Attributes
 * `node["tomcat"]["deploy_manager_apps"]` - whether to deploy manager apps, default `true`.
 * `node["tomcat"]["authbind"]` - whether to bind tomcat on lower port numbers, default `no`.
 * `node["tomcat"]["max_threads"]` - maximum number of threads in the connector pool.
+* `node["tomcat"]["autostart"]` - if set to false, don't start Tomcat or restart it in case of config change, default `true`.
 * `node["tomcat"]["tomcat_auth"]` -
 * `node["tomcat"]["user"]` -
 * `node["tomcat"]["group"]` -

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,7 @@ default['tomcat']['java_options'] = '-Xmx128M -Djava.awt.headless=true'
 default['tomcat']['use_security_manager'] = false
 default['tomcat']['authbind'] = 'no'
 default['tomcat']['deploy_manager_apps'] = true
+default['tomcat']['ssl_enable'] = true
 default['tomcat']['ssl_max_threads'] = 150
 default['tomcat']['ssl_cert_file'] = nil
 default['tomcat']['ssl_key_file'] = nil
@@ -43,6 +44,7 @@ default['tomcat']['truststore_type'] = 'jks'
 default['tomcat']['certificate_dn'] = 'cn=localhost'
 default['tomcat']['loglevel'] = 'INFO'
 default['tomcat']['tomcat_auth'] = 'true'
+default['tomcat']['autostart'] = 'true'
 
 case node['platform']
 when 'centos', 'redhat', 'fedora', 'amazon'


### PR DESCRIPTION
These changes don't change the default behavior.  If node['tomcat']['ssl_enable'] is set to false, the SSL configuration block will be skipped.  If node['tomcat']['autostart'] is set to true, Tomcat will not start upon completion of the client run.  It will also not restart when configs are modified.