### PR TITLE
Fix trailing comma that cause Fatal SyntaxErrors

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,7 +26,7 @@ tomcat_pkgs = value_for_platform(
   ['smartos'] => {
     'default' => ['apache-tomcat'],
   },
-  'default' => ["tomcat#{node['tomcat']['base_version']}"],
+  'default' => ["tomcat#{node['tomcat']['base_version']}"]
   )
 if node['tomcat']['deploy_manager_apps']
   tomcat_pkgs << value_for_platform(
@@ -35,7 +35,7 @@ if node['tomcat']['deploy_manager_apps']
     },
     %w{ centos redhat fedora amazon } => {
       'default' => "tomcat#{node['tomcat']['base_version']}-admin-webapps",
-    },
+    }
     )
 end
 


### PR DESCRIPTION
Got the following errors

```
[2014-03-04T06:08:57+00:00] FATAL: SyntaxError: compile error
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/tomcat/recipes/default.rb:30: syntax error, unexpected ')'
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/tomcat/recipes/default.rb:39: syntax error, unexpected ')'
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/tomcat/recipes/default.rb:201: syntax error, unexpected $end, expecting kEND
```

Resolved by this update
