### PR TITLE
[COOK-4301] Replace 'node.set' with 'node.default'

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -78,7 +78,7 @@ unless node['tomcat']['truststore_file'].nil?
   java_options << " -Djavax.net.ssl.trustStore=#{node['tomcat']['config_dir']}/#{node['tomcat']['truststore_file']}"
   java_options << " -Djavax.net.ssl.trustStorePassword=#{node['tomcat']['truststore_password']}"
 
-  node.set['tomcat']['java_options'] = java_options
+  node.default['tomcat']['java_options'] = java_options
 end
 
 case node['platform']


### PR DESCRIPTION
This change is to replace 'node.set' with 'node.default' at line 81. After this change 'java_options' attribute becomes a 'default' attribute which gets reset at each chef client hence there won't be any duplication of truststore options anymore.
