### PR TITLE
[COOK-4209] Removed XML Validation attributes

### DIFF
--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -149,7 +149,10 @@
        -->
       <Host name="localhost"  appBase="webapps"
             unpackWARs="true" autoDeploy="true"
-            xmlValidation="false" xmlNamespaceAware="false">
+            <% if node['tomcat']['base_version'].to_i < 7 -%>
+            xmlValidation="false" xmlNamespaceAware="false"
+            <% end -%>
+            >
 
         <!-- SingleSignOn valve, share authentication between web applications
              Documentation at: /docs/config/valve.html -->


### PR DESCRIPTION
The XML attributes xmlValidation and xmlNamespaceAware have been removed from the default Host element in the server.xml.erb template file if the tomcat base_version is >= 7
