### PR TITLE
Overrideable Retry Delay

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,6 +43,7 @@ default['tomcat']['truststore_type'] = 'jks'
 default['tomcat']['certificate_dn'] = 'cn=localhost'
 default['tomcat']['loglevel'] = 'INFO'
 default['tomcat']['tomcat_auth'] = 'true'
+default['tomcat']['retry_delay'] = 30
 
 case node['platform']
 when 'centos', 'redhat', 'fedora', 'amazon'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -192,7 +192,7 @@ service 'tomcat' do
   action [:start, :enable]
   notifies :run, 'execute[wait for tomcat]', :immediately
   retries 4
-  retry_delay 30
+  retry_delay node['tomcat']['retry_delay']
 end
 
 execute 'wait for tomcat' do


### PR DESCRIPTION
- On systems with lower cpu power or under load, the restart delay must be set higher or the service start will fail.
