### PR TITLE
Setup address attribute for Connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Attributes
 ----------
 * `node["tomcat"]["base_version"]` - The version of tomcat to install, default `6`.
 * `node["tomcat"]["port"]` - The network port used by Tomcat's HTTP connector, default `8080`.
+* `node["tomcat"]["address"]` - The network address used by Tomcat's HTTP connector, default `nil`. For servers with more than one IP address, this attribute specifies which address will be used for listening on the specified port. By default, this port will be used on all IP addresses associated with the server.
 * `node["tomcat"]["proxy_port"]` - if set, the network port used by Tomcat's Proxy HTTP connector, default nil.
 * `node["tomcat"]["ssl_port"]` - The network port used by Tomcat's SSL HTTP connector, default `8443`.
 * `node["tomcat"]["ssl_proxy_port"]` - if set, the network port used by Tomcat's Proxy SSL HTTP connector, default nil.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,7 @@
 
 default['tomcat']['base_version'] = 6
 default['tomcat']['port'] = 8080
+default['tomcat']['address'] = nil
 default['tomcat']['proxy_port'] = nil
 default['tomcat']['ssl_port'] = 8443
 default['tomcat']['ssl_proxy_port'] = nil

--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -77,6 +77,9 @@
     <Connector port="<%= node["tomcat"]["port"] %>" protocol="HTTP/1.1"
                connectionTimeout="20000"
                URIEncoding="UTF-8"
+             <% if node['tomcat']['address'] -%>
+               address="<%= node['tomcat']['address'] %>"
+             <% end -%>
              <% if node["tomcat"].has_key?("proxy_port") -%>
                proxyPort="<%= node["tomcat"]["proxy_port"] %>"
              <% end -%>


### PR DESCRIPTION
Added attribute `address` to specify an server listen address.
Added support optional attribute of Connector in `server.xml` to setup address.
For servers with more than one IP address, this attribute specifies which address will be used for listening on the
specified port.
By default, this port will be used on all IP addresses associated with the server.
Updated README about new option.