### PR TITLE
[COOK-4617] Added service name attribute.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -60,6 +60,7 @@ when 'centos', 'redhat', 'fedora', 'amazon', 'scientific', 'oracle'
   default['tomcat']['keytool'] = 'keytool'
   default['tomcat']['lib_dir'] = "#{node["tomcat"]["home"]}/lib"
   default['tomcat']['endorsed_dir'] = "#{node["tomcat"]["lib_dir"]}/endorsed"
+  default['tomcat']['service'] = "tomcat#{node['tomcat']['base_version']}"
 when 'debian', 'ubuntu'
   default['tomcat']['user'] = "tomcat#{node["tomcat"]["base_version"]}"
   default['tomcat']['group'] = "tomcat#{node["tomcat"]["base_version"]}"
@@ -74,6 +75,7 @@ when 'debian', 'ubuntu'
   default['tomcat']['keytool'] = 'keytool'
   default['tomcat']['lib_dir'] = "#{node["tomcat"]["home"]}/lib"
   default['tomcat']['endorsed_dir'] = "#{node["tomcat"]["lib_dir"]}/endorsed"
+  default['tomcat']['service'] = "tomcat#{node['tomcat']['base_version']}"
 when 'smartos'
   default['tomcat']['user'] = 'tomcat'
   default['tomcat']['group'] = 'tomcat'
@@ -88,6 +90,7 @@ when 'smartos'
   default['tomcat']['keytool'] = '/opt/local/bin/keytool'
   default['tomcat']['lib_dir'] = "#{node["tomcat"]["home"]}/lib"
   default['tomcat']['endorsed_dir'] = "#{node["tomcat"]["home"]}/lib/endorsed"
+  default['tomcat']['service'] = "tomcat"
 else
   default['tomcat']['user'] = "tomcat#{node["tomcat"]["base_version"]}"
   default['tomcat']['group'] = "tomcat#{node["tomcat"]["base_version"]}"
@@ -102,4 +105,5 @@ else
   default['tomcat']['keytool'] = 'keytool'
   default['tomcat']['lib_dir'] = "#{node["tomcat"]["home"]}/lib"
   default['tomcat']['endorsed_dir'] = "#{node["tomcat"]["lib_dir"]}/endorsed"
+  default['tomcat']['service'] = "tomcat#{node['tomcat']['base_version']}"
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -176,18 +176,14 @@ unless node['tomcat']['truststore_file'].nil?
 end
 
 service 'tomcat' do
+  service_name node['tomcat']['service']
   case node['platform']
   when 'centos', 'redhat', 'fedora', 'amazon'
-    service_name "tomcat#{node['tomcat']['base_version']}"
     supports :restart => true, :status => true
   when 'debian', 'ubuntu'
-    service_name "tomcat#{node['tomcat']['base_version']}"
     supports :restart => true, :reload => false, :status => true
   when 'smartos'
-    service_name 'tomcat'
     supports :restart => false, :reload => false, :status => true
-  else
-    service_name "tomcat#{node['tomcat']['base_version']}"
   end
   action [:start, :enable]
   notifies :run, 'execute[wait for tomcat]', :immediately


### PR DESCRIPTION
CLA: Signed (waiting for Developer status in Jira, so I can mark it as 'Fix Provided')
Ticket: https://tickets.opscode.com/browse/COOK-4617

Add a service name attribute, so it can be re-used in other cookbooks that depend on tomcat cookbook.

----

For example, the `application_java` cookbook uses hardcoded `tomcat` service name currently:
https://github.com/poise/application_java/blob/master/providers/tomcat.rb#L48

In the future it may use this attribute, because it already depends on tomcat cookbook.