### PR TITLE
Cook-4667

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Attributes
 * `node["tomcat"]["max_threads"]` - maximum number of threads in the connector pool.
 * `node["tomcat"]["tomcat_auth"]` -
 * `node["tomcat"]["user"]` -
+* `node["tomcat"]["service_action"]` - Action to be passed to the tomcat service resource.
 * `node["tomcat"]["group"]` -
 * `node["tomcat"]["home"]` -
 * `node["tomcat"]["base"]` -

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,6 +43,7 @@ default['tomcat']['truststore_type'] = 'jks'
 default['tomcat']['certificate_dn'] = 'cn=localhost'
 default['tomcat']['loglevel'] = 'INFO'
 default['tomcat']['tomcat_auth'] = 'true'
+default['tomcat']['service_action'] = 'enable_start'
 
 case node['platform']
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -229,4 +229,9 @@ when 'nothing'
   service 'tomcat' do
     action :nothing
   end
+else
+  Chef::Log.warn("node['tomcat']['service_action'] was set to: '#{node['tomcat']['service_action']}', setting to :nothing. Acceptable attributes 'start, enable, enable_start, stop, disable, disable_stop, nothing'")
+  service 'tomcat' do
+    action :nothing
+  end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -189,7 +189,7 @@ service 'tomcat' do
   else
     service_name "tomcat#{node['tomcat']['base_version']}"
   end
-  action [:start, :enable]
+  action :nothing
   notifies :run, 'execute[wait for tomcat]', :immediately
   retries 4
   retry_delay 30
@@ -198,4 +198,35 @@ end
 execute 'wait for tomcat' do
   command 'sleep 5'
   action :nothing
+end
+
+case node['tomcat']['service_action']
+when 'start'
+  service 'tomcat' do
+    action :start
+  end
+when 'enable'
+  service 'tomcat' do
+    action :enable
+  end
+when 'enable_start'
+  service 'tomcat' do
+    action [ :enable, :start ]
+  end
+when 'stop'
+  service 'tomcat' do
+    action :stop
+  end
+when 'disable'
+  service 'tomcat' do
+    action :disable
+  end
+when 'disable_stop' 
+  service 'tomcat' do
+    action :disable_stop
+  end
+when 'nothing'
+  service 'tomcat' do
+    action :nothing
+  end
 end


### PR DESCRIPTION
Hey friends,

I need to be able to have no action taken on the tomcat service resource at time of convergence. There was another pr (https://github.com/opscode-cookbooks/tomcat/pull/57) doing something simliar, but this is much more flexible and I don't care about the SSL changes being implemented there.

Updated the readme with attribute description as well as added logging output for invalid actions.

https://tickets.opscode.com/browse/COOK-4667