### PR TITLE
add multicast support. fix various brokenness

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Attributes
 * `node["tomcat"]["webapp_dir"]` -
 * `node["tomcat"]["lib_dir"]` -
 * `node["tomcat"]["endorsed_dir"]` -
+* `node["tomcat"]["cluster_multicast_ip"]` - Multicast address for clustering. Unique clusters should have a unique ip:port.
+* `node["tomcat"]["cluster_multicast_port"]` -
+* `node["tomcat"]["cluster_multicast_freq"]` -
+* `node["tomcat"]["cluster_multicast_drop"]` -
 
 ### Attributes for SSL
 * `node["tomcat"]["ssl_cert_file"]` - SSL certificate file
@@ -79,7 +83,7 @@ Running Multiple Instances
 --------------------------
 To run multiple instances of Tomcat, populate the `instances` attribute, which is a dictionary of instance name => array of attributes.  Most of the same attributes that can be used globally for the tomcat cookbook can also be set per-instance - see resources/instance.rb for details.
 
-If they are not set for a particular instance, the `base`, `home`, `config_dir`, `log_dir`, `work_dir`, `context_dir`, and `webapp_dir` attributes are created by modifying the global values to use the instance name.  For example, under Tomcat 7, with `home` /usr/share/tomcat7, `home` for instance "instance1" would be set to /usr/share/tomcat7-instance1.  The port attributes - `port`, `proxy_port`, `ssl_port`, `ssl_proxy_port`, `ajp_port`, and `shutdown_port` - are not inherited and must be set per-instance.  Other attributes that are not set are inherited unmodified from the global attributes.  Each instance must define `shutdown_port`, and at least one of `port`, `ssl_port` or `ajp_port`.
+If they are not set for a particular instance, the `base`, `home`, `config_dir`, `log_dir`, `work_dir`, `context_dir`, and `webapp_dir` attributes are created by modifying the global values to use the instance name.  For example, under Tomcat 7, with `home` /usr/share/tomcat7, `home` for instance "instance1" would be set to /usr/share/tomcat7-instance1.  The port attributes - `port`, `proxy_port`, `ssl_port`, `ssl_proxy_port`, `ajp_port`, and `shutdown_port` - are not inherited and must be set per-instance. If clustering is used, `cluster_multicast_ip` must be set for each instance. Other attributes that are not set are inherited unmodified from the global attributes.  Each instance must define `shutdown_port`, and at least one of `port`, `ssl_port` or `ajp_port`.
 
 If you only want to run specific instances and not the "base" tomcat instances, you can set `run_base_instance` to `false`.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,10 @@ default['tomcat']['ssl_port'] = 8443
 default['tomcat']['ssl_proxy_port'] = nil
 default['tomcat']['ajp_port'] = 8009
 default['tomcat']['shutdown_port'] = 8005
+default['tomcat']['cluster_multicast_ip'] = nil #"228.0.0.4"
+default['tomcat']['cluster_multicast_port'] = 45564
+default['tomcat']['cluster_multicast_freq'] = 500
+default['tomcat']['cluster_multicast_drop'] = 15000
 default['tomcat']['catalina_options'] = ''
 default['tomcat']['java_options'] = '-Xmx128M -Djava.awt.headless=true'
 default['tomcat']['use_security_manager'] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -76,6 +76,7 @@ if node['tomcat']['run_base_instance']
     ssl_proxy_port node['tomcat']['ssl_proxy_port']
     ajp_port node['tomcat']['ajp_port']
     shutdown_port node['tomcat']['shutdown_port']
+    cluster_multicast_ip node['tomcat']['cluster_multicast_ip']
   end
 end
 
@@ -87,6 +88,10 @@ node['tomcat']['instances'].each do |name, attrs|
     ssl_proxy_port attrs['ssl_proxy_port']
     ajp_port attrs['ajp_port']
     shutdown_port attrs['shutdown_port']
+    cluster_multicast_ip attrs['cluster_multicast_ip']
+    cluster_multicast_port attrs['cluster_multicast_port']
+    cluster_multicast_freq attrs['cluster_multicast_freq']
+    cluster_multicast_drop attrs['cluster_multicast_drop']
     config_dir attrs['config_dir']
     log_dir attrs['log_dir']
     work_dir attrs['work_dir']

--- a/resources/instance.rb
+++ b/resources/instance.rb
@@ -20,6 +20,8 @@ attribute :ajp_port,
 attribute :shutdown_port,
   :kind_of => Fixnum,
   :required => true
+attribute :cluster_multicast_ip,
+  :kind_of => String
 
 # The rest will inherit from node attributes
 attribute :config_dir,
@@ -84,3 +86,10 @@ attribute :lib_dir,
   :kind_of => String
 attribute :endorsed_dir,
   :kind_of => String
+
+attribute :cluster_multicast_port,
+  :kind_of => Fixnum
+attribute :cluster_multicast_freq,
+  :kind_of => Fixnum
+attribute :cluster_multicast_drop,
+  :kind_of => Fixnum

--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -84,8 +84,9 @@
                maxThreads="<%= @max_threads %>"
              <% end -%>
              <% if @ssl_port -%>
-               redirectPort="<%= @ssl_port %>" />
-             <% end -%>
+               redirectPort="<%= @ssl_port %>" 
+             <% end -%> 
+             />
   <% end -%>
     <!-- A "Connector" using the shared thread pool-->
     <!--
@@ -93,8 +94,9 @@
                port="<%= @port %>" protocol="HTTP/1.1"
                connectionTimeout="20000"
              <% if @ssl_port -%>
-               redirectPort="<%= @ssl_port %>" />
+               redirectPort="<%= @ssl_port %>" 
              <% end -%>
+             />
     -->
   <% if @ssl_port -%>
     <!-- Define a SSL HTTP/1.1 Connector on port <%= @ssl_port %>
@@ -138,6 +140,18 @@
       <!--
       <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
       -->
+      <% if @cluster_multicast_ip -%>
+      <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"
+               channelSendOptions="8">
+                <Channel className="org.apache.catalina.tribes.group.GroupChannel">
+                    <Membership className="org.apache.catalina.tribes.membership.McastService"
+                                address="<%= @cluster_multicast_ip -%>"
+                                port="<%= @cluster_multicast_port -%>"
+                                frequency="<%= @cluster_multicast_freq -%>"
+                                dropTime="<%= @cluster_multicast_drop -%>"/>
+                </Channel>
+      </Cluster>
+      <% end -%>
 
       <!-- The request dumper valve dumps useful debugging information about
            the request and response data received and sent by Tomcat.


### PR DESCRIPTION
This patch adds multicast-based clustering/session replication support. It also fixes some issues I found in testing tomcat6 and tomcat7 (from http://ftp.pbone.net/mirror/www.jpackage.org/jpackage/6.0/generic/free/ on CentOS6) on CentOS6 and Ubuntu14.04.

I've signed the CLA as 'elijahbuck', but I don't know where you are on the transition to a pure-GitHub process. Do I need to create a ticket in JIRA?

Changes are:

* Adds four attributes, cluster_multicast_*
* Ubuntu 14.04 tomcat 6 doesn't have catlina.policy, it has policy.d
* 'bin/' and 'lib/' are under #{node['tomcat']['home']} in ubuntu and redhat. They are not under "#{node['tomcat']['base]} on ubuntu.
* webapp_dir is already at "#{new_resource.base}/#{name}" on ubuntu 14.04, so we can't create a symlink to it.
* The tomcat init scripts on CentOS expect /usr/sbin/tomcat6 or /usr/sbin/dtomcat7, and the init script copy blindly replaces 'tomcat<version>' with 'tomcat<version>-<instance>', which breaks the init script. So, we create a link to the init script with the 'mangled' name.
* The xml elements in server.xml should be terminated with '/>' even if redirectPort isn't defined.