### PR TITLE
Fix for 'could not find service[tomcat]' in users recipe.

### DIFF
--- a/recipes/users.rb
+++ b/recipes/users.rb
@@ -18,6 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+base_instance = "tomcat#{node['tomcat']['base_version']}"
 
 template "#{node["tomcat"]["config_dir"]}/tomcat-users.xml" do
   source 'tomcat-users.xml.erb'
@@ -28,5 +29,5 @@ template "#{node["tomcat"]["config_dir"]}/tomcat-users.xml" do
     :users => TomcatCookbook.users,
     :roles => TomcatCookbook.roles,
   )
-  notifies :restart, 'service[tomcat]'
+  notifies :restart, "service[#{base_instance}]"
 end


### PR DESCRIPTION
Related issue: #76

Don't know if could be better to integrate this function in the new multi-instance provider.