### PR TITLE
Fixing setting appBase in server.xml via node[:tomcat][:webapp_dir]

### DIFF
--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -169,6 +169,7 @@ action :configure do
         :keystore_type => new_resource.keystore_type,
         :tomcat_auth => new_resource.tomcat_auth,
         :config_dir => new_resource.config_dir,
+        :webapp_dir => new_resource.webapp_dir
       })
     owner 'root'
     group 'root'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -76,6 +76,7 @@ if node['tomcat']['run_base_instance']
     ssl_proxy_port node['tomcat']['ssl_proxy_port']
     ajp_port node['tomcat']['ajp_port']
     shutdown_port node['tomcat']['shutdown_port']
+    webapp_dir node['tomcat']['webapp_dir']
   end
 end
 

--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -157,7 +157,7 @@
       <!-- Define the default virtual host
            Note: XML Schema validation will not work with Xerces 2.2.
        -->
-      <Host name="localhost"  appBase="webapps"
+      <Host name="localhost"  appBase="<%= @webapp_dir %>"
             unpackWARs="true" autoDeploy="true"
             <% if node['tomcat']['base_version'].to_i < 7 -%>
             xmlValidation="false" xmlNamespaceAware="false"


### PR DESCRIPTION
Documentation states that this cookbook can set appBase in a <Host /> declaration in server.xml using node[:tomcat][:webapp_dir]. This does not work for base instances or with multiple instances. This PR resolves that problem.