### PR TITLE
added address option for enabling restricted setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Gemfile.lock
 bin
 .kitchen.local.yml
 .coverage
+.project

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Requirements
 Attributes
 ----------
 * `node["tomcat"]["base_version"]` - The version of tomcat to install, default `6`.
+* `node["tomcat"]["address"]` - The network ip address used by Tomcat's HTTP connector, default nil.
 * `node["tomcat"]["port"]` - The network port used by Tomcat's HTTP connector, default `8080`.
 * `node["tomcat"]["proxy_port"]` - if set, the network port used by Tomcat's Proxy HTTP connector, default nil.
 * `node["tomcat"]["ssl_port"]` - The network port used by Tomcat's SSL HTTP connector, default `8443`.

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -12,7 +12,7 @@ action :configure do
     if not new_resource.instance_variable_get("@#{attr}")
       new_resource.instance_variable_set("@#{attr}", node['tomcat'][attr])
     end
-  end 
+  end
 
   if new_resource.name == 'base'
     instance = base_instance
@@ -157,6 +157,7 @@ action :configure do
   template "#{new_resource.config_dir}/server.xml" do
     source 'server.xml.erb'
       variables ({
+        :address => new_resource.address,
         :port => new_resource.port,
         :proxy_port => new_resource.proxy_port,
         :ssl_port => new_resource.ssl_port,

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,7 +32,7 @@ if node['tomcat']['deploy_manager_apps']
   tomcat_pkgs << value_for_platform(
     %w{ debian  ubuntu } => {
       'default' => "tomcat#{node['tomcat']['base_version']}-admin",
-    },    
+    },
     %w{ centos redhat fedora amazon scientific oracle } => {
       'default' => "tomcat#{node['tomcat']['base_version']}-admin-webapps",
     }
@@ -70,6 +70,7 @@ node.set_unless['tomcat']['truststore_password'] = secure_password
 
 if node['tomcat']['run_base_instance']
   tomcat_instance "base" do
+    address node['tomcat']['address']
     port node['tomcat']['port']
     proxy_port node['tomcat']['proxy_port']
     ssl_port node['tomcat']['ssl_port']
@@ -81,6 +82,7 @@ end
 
 node['tomcat']['instances'].each do |name, attrs|
   tomcat_instance "#{name}" do
+    address attrs['address']
     port attrs['port']
     proxy_port attrs['proxy_port']
     ssl_port attrs['ssl_port']

--- a/resources/instance.rb
+++ b/resources/instance.rb
@@ -7,6 +7,8 @@ attribute :name,
   :kind_of => String,
   :required => true,
   :name_attribute => true
+attribute :address,
+  :kind_of => String
 attribute :port,
   :kind_of => Fixnum
 attribute :proxy_port,

--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -74,7 +74,11 @@
          APR (HTTP/AJP) Connector: /docs/apr.html
          Define a non-SSL HTTP/1.1 Connector on port <%= @port %>
     -->
+    <% if @address -%>
+    <Connector address="<%= @address %>" port="<%= @port %>" protocol="HTTP/1.1"
+    <% else -%>
     <Connector port="<%= @port %>" protocol="HTTP/1.1"
+    <% end -%>
                connectionTimeout="20000"
                URIEncoding="UTF-8"
              <% if @proxy_port -%>

--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -106,7 +106,11 @@
          This connector uses the JSSE configuration, when using APR, the
          connector should be using the OpenSSL style configuration
          described in the APR documentation -->
+    <% if @address -%>
+    <Connector address="<%= @address %>" port="<%= @ssl_port %>" protocol="HTTP/1.1" SSLEnabled="true"
+    <% else -%>
     <Connector port="<%= @ssl_port %>" protocol="HTTP/1.1" SSLEnabled="true"
+    <% end -%>
              <% if @ssl_proxy_port -%>
                proxyPort="<%= @ssl_proxy_port %>"
              <% end -%>
@@ -120,7 +124,11 @@
 
   <% if @ajp_port -%>
     <!-- Define an AJP 1.3 Connector on port <%= @ajp_port %> -->
+    <% if @address -%>
+    <Connector address="<%= @address %>" port="<%= @ajp_port %>"
+    <% else -%>
     <Connector port="<%= @ajp_port %>"
+    <% end -%>
                protocol="AJP/1.3"
                tomcatAuthentication="<%= @tomcat_auth %>"
                redirectPort="<%= @ssl_port %>" />


### PR DESCRIPTION
Hi,

because my tomcat instance is only accessible from localhost, I have to set the address attribute of the connector tag. This was not possible right now, so I added the support for the config option.

Please add the "feature" to your cookbook.


best regards,

Christian Kaspar