### PR TITLE
Added ability to specify value associated with the Server header in HTTP responses.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,6 +47,7 @@ default['tomcat']['loglevel'] = 'INFO'
 default['tomcat']['tomcat_auth'] = 'true'
 default['tomcat']['instances'] = {}
 default['tomcat']['run_base_instance'] = true
+default['tomcat']['server_name'] = nil
 
 case node['platform']
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@opscode.com'
 license          'Apache 2.0'
 description      'Installs/Configures tomcat'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.16.2'
+version          '0.16.3'
 
 depends 'java'
 depends 'openssl'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@opscode.com'
 license          'Apache 2.0'
 description      'Installs/Configures tomcat'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.16.3'
+version          '0.16.2'
 
 depends 'java'
 depends 'openssl'

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -8,7 +8,7 @@ action :configure do
    :max_threads, :ssl_max_threads, :ssl_cert_file, :ssl_key_file,
    :ssl_chain_files, :keystore_file, :keystore_type, :truststore_file,
    :truststore_type, :certificate_dn, :loglevel, :tomcat_auth, :user,
-   :group, :tmp_dir, :lib_dir, :endorsed_dir].each do |attr|
+   :group, :tmp_dir, :lib_dir, :endorsed_dir, :server_name].each do |attr|
     if not new_resource.instance_variable_get("@#{attr}")
       new_resource.instance_variable_set("@#{attr}", node['tomcat'][attr])
     end
@@ -169,6 +169,7 @@ action :configure do
         :keystore_type => new_resource.keystore_type,
         :tomcat_auth => new_resource.tomcat_auth,
         :config_dir => new_resource.config_dir,
+        :server_name => new_resource.server_name
       })
     owner 'root'
     group 'root'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -81,6 +81,7 @@ end
 
 node['tomcat']['instances'].each do |name, attrs|
   tomcat_instance "#{name}" do
+    server_name attrs['server_name']
     port attrs['port']
     proxy_port attrs['proxy_port']
     ssl_port attrs['ssl_port']

--- a/resources/instance.rb
+++ b/resources/instance.rb
@@ -69,6 +69,8 @@ attribute :loglevel,
 attribute :tomcat_auth,
   :kind_of => String,
   :equal_to => ['true', 'false']
+attribute :server_name,
+  :kind_of => String
 
 attribute :user,
   :kind_of => String

--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -86,6 +86,9 @@
              <% if @ssl_port -%>
                redirectPort="<%= @ssl_port %>"
              <% end -%>
+             <% if @server_name %>
+               Server="<%= @server_name %>"
+             <% end -%>
              />
   <% end -%>
     <!-- A "Connector" using the shared thread pool-->
@@ -105,6 +108,9 @@
     <Connector port="<%= @ssl_port %>" protocol="HTTP/1.1" SSLEnabled="true"
              <% if @ssl_proxy_port -%>
                proxyPort="<%= @ssl_proxy_port %>"
+             <% end -%>
+             <% if @server_name %>
+               Server="<%= @server_name %>"
              <% end -%>
                keystoreFile="<%= @config_dir %>/<%= @keystore_file %>"
                keystorePass="<%= node['tomcat']['keystore_password'] %>"


### PR DESCRIPTION
This replaces the server version string from HTTP headers in server responses, by adding the server keyword to the tomcat Connectors in CATALINA_HOME/conf/server.xml.

The default value for this header when it has not been defined in the connector is: Server: Apache-Coyote/1.1.

By overriding default['tomcat']['server_name'] you now have the ability to change the value associated with this header in HTTP responses.

OWASP defines this as a best practice for securing tomcat installations: https://www.owasp.org/index.php/Securing_tomcat 

Please review these changes.