### PR TITLE
Adding attribute for user-defined environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Attributes
 * `node["tomcat"]["tomcat_auth"]` -
 * `node["tomcat"]["instances"]` - A dictionary defining additional tomcat instances to run.
 * `node["tomcat"]["run_base_instance"]` - Whether or not to run the "base" tomcat instance, default `true`.
+* `node["tomcat"]["environment"]` - Environment variables to be setup when starting Tomcat
 * `node["tomcat"]["user"]` -
 * `node["tomcat"]["group"]` -
 * `node["tomcat"]["home"]` -

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,6 +47,7 @@ default['tomcat']['loglevel'] = 'INFO'
 default['tomcat']['tomcat_auth'] = 'true'
 default['tomcat']['instances'] = {}
 default['tomcat']['run_base_instance'] = true
+default['tomcat']['environment'] = []
 
 case node['platform']
 

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -176,6 +176,14 @@ action :configure do
     notifies :restart, "service[#{instance}]"
   end
 
+  template "#{new_resource.config_dir}/context.xml" do
+    source 'context.xml.erb'
+    owner 'root'
+    group 'root'
+    mode '0644'
+    notifies :restart, "service[#{instance}]"
+  end
+
   template "#{new_resource.config_dir}/logging.properties" do
     source 'logging.properties.erb'
     owner 'root'

--- a/templates/default/context.xml.erb
+++ b/templates/default/context.xml.erb
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- The contents of this file will be loaded for each web application -->
+<Context useHttpOnly="true">
+
+    <!-- Default set of monitored resources -->
+    <WatchedResource>WEB-INF/web.xml</WatchedResource>
+
+    <!-- Uncomment this to disable session persistence across Tomcat restarts -->
+    <!--
+    <Manager pathname="" />
+    -->
+
+    <!-- Uncomment this to enable Comet connection tacking (provides events
+         on session expiration as well as webapp lifecycle) -->
+    <!--
+    <Valve className="org.apache.catalina.valves.CometConnectionManagerValve" />
+    -->
+
+</Context>

--- a/templates/default/default_tomcat6.erb
+++ b/templates/default/default_tomcat6.erb
@@ -69,7 +69,8 @@ CATALINA_OPTS="<%= @catalina_options %>"
 # Endorse .jar files in this directory
 JAVA_ENDORSED_DIRS="<%= @endorsed_dir %>"
 
-#Environment variables
-<% @node["tomcat"]["environment"].each do |env| -%>
-<% env['VariableName']-%>="<% env['VariableValue']-%>"
+# User-defined Environment variables
+<% @node["tomcat"]["environment"].each do |envvar| -%>
+<%= envvar['VariableName']-%>="<%= envvar['VariableValue']-%>"
 <% end -%>
+

--- a/templates/default/default_tomcat6.erb
+++ b/templates/default/default_tomcat6.erb
@@ -68,3 +68,8 @@ CATALINA_OPTS="<%= @catalina_options %>"
 
 # Endorse .jar files in this directory
 JAVA_ENDORSED_DIRS="<%= @endorsed_dir %>"
+
+#Environment variables
+<% @node["tomcat"]["environment"].each do |env| -%>
+<% env['VariableName']-%>="<% env['VariableValue']-%>"
+<% end -%>

--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -86,7 +86,7 @@
              <% if @ssl_port -%>
                redirectPort="<%= @ssl_port %>"
              <% end -%>
-             server = ""
+             server=" "
              secure="true"
              />
   <% end -%>

--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -86,6 +86,7 @@
              <% if @ssl_port -%>
                redirectPort="<%= @ssl_port %>"
              <% end -%>
+             secure="true"
              />
   <% end -%>
     <!-- A "Connector" using the shared thread pool-->

--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -86,6 +86,7 @@
              <% if @ssl_port -%>
                redirectPort="<%= @ssl_port %>"
              <% end -%>
+             server = ""
              secure="true"
              />
   <% end -%>

--- a/templates/default/setenv.sh.erb
+++ b/templates/default/setenv.sh.erb
@@ -13,6 +13,6 @@ export CATALINA_OPTS='<%= node["tomcat"]["catalina_options"] %>'
 export CATALINA_PID='<%= node["tomcat"]["log_dir"] %>/catalina.pid'
 
 # User-defined Environment variables
-<% @node["tomcat"]["environment"].each do |env| -%>
-<% env['VariableName']-%>='<% env['VariableValue']-%>'
+<% @node["tomcat"]["environment"].each do |envvar| -%>
+<%= envvar['VariableName']-%>='<%= envvar['VariableValue']-%>'
 <% end -%>

--- a/templates/default/setenv.sh.erb
+++ b/templates/default/setenv.sh.erb
@@ -11,3 +11,8 @@ export CATALINA_BASE='<%= node["tomcat"]["base"] %>'
 export JAVA_OPTS='<%= node["tomcat"]["java_options"] %>'
 export CATALINA_OPTS='<%= node["tomcat"]["catalina_options"] %>'
 export CATALINA_PID='<%= node["tomcat"]["log_dir"] %>/catalina.pid'
+
+# User-defined Environment variables
+<% @node["tomcat"]["environment"].each do |env| -%>
+<% env['VariableName']-%>='<% env['VariableValue']-%>'
+<% end -%>

--- a/templates/default/sysconfig_tomcat6.erb
+++ b/templates/default/sysconfig_tomcat6.erb
@@ -64,6 +64,7 @@ JAVA_ENDORSED_DIRS="<%= @endorsed_dir %>"
 # (i.e. LD_LIBRARY_PATH for some jdbc drivers)
 
 # User-defined Environment variables
-<% @node["tomcat"]["environment"].each do |env| -%>
-<% env['VariableName']-%>="<% env['VariableValue']-%>"
+<% @node["tomcat"]["environment"].each do |envvar| -%>
+<%= envvar['VariableName']-%>="<%= envvar['VariableValue']-%>"
 <% end -%>
+

--- a/templates/default/sysconfig_tomcat6.erb
+++ b/templates/default/sysconfig_tomcat6.erb
@@ -63,3 +63,7 @@ JAVA_ENDORSED_DIRS="<%= @endorsed_dir %>"
 # put your own definitions here
 # (i.e. LD_LIBRARY_PATH for some jdbc drivers)
 
+# User-defined Environment variables
+<% @node["tomcat"]["environment"].each do |env| -%>
+<% env['VariableName']-%>="<% env['VariableValue']-%>"
+<% end -%>


### PR DESCRIPTION
This change will allow the generation of user-defined environment variables that are set before Tomcat is started.
Usage would be:

        envs = []
        envs.push({'VariableName' => 'LOCAL_HOME', 'VariableValue' => '/usr/root'})
        envs.push({'VariableName' => 'CONFIG_URL', 'VariableValue' => 'http://127.0.0.1/config'})
        node.default['tomcat']['environment'] = envs