### PR TITLE
Ensure CATALINA_PID takes effect for instances on RHEL

### DIFF
--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -123,6 +123,7 @@ action :configure do
     template "/etc/sysconfig/#{instance}" do
       source 'sysconfig_tomcat6.erb'
       variables ({
+        :instance => instance,
         :user => new_resource.user,
         :home => new_resource.home,
         :base => new_resource.base,
@@ -136,6 +137,12 @@ action :configure do
       group 'root'
       mode '0644'
       notifies :restart, "service[#{instance}]"
+    end
+    file "/var/run/#{instance}.pid" do
+      owner new_resource.user
+      group new_resource.group
+      mode '0644'
+      action :create_if_missing
     end
   when 'smartos'
     # SmartOS doesn't support multiple instances

--- a/templates/default/sysconfig_tomcat6.erb
+++ b/templates/default/sysconfig_tomcat6.erb
@@ -51,7 +51,7 @@ SECURITY_MANAGER="<%= @use_security_manager %>"
 #SHUTDOWN_VERBOSE="false"
 
 # Set the TOMCAT_PID location
-#CATALINA_PID="/var/run/tomcat6.pid"
+CATALINA_PID="/var/run/<%= @instance %>.pid"
 
 # JVM parameters passed only for start and run commands
 CATALINA_OPTS="<%= @catalina_options %>"


### PR DESCRIPTION
Under RHEL 7, `/usr/sbin/tomcat-sysd` sets `CATALINA_PID` for the given
instance but it is erroneously replaced with the default value from
`/etc/tomcat/tomcat.conf`. The only way to work around this is to also
set it in the instance's sysconfig file.

This doesn't change the fact that `/var/run` is only writeable by root.
Any new PID files need to be put in place beforehand as the script
does not set the correct permissions for us. It actually says it does
in the comments… but it doesn't! This is fixed here with a file
resource.

Recent Fedora releases use JSVC to launch Tomcat instead so all this
will most likely change in RHEL 8.