### PR TITLE
Service can not restart in Rhel/Centos because the default is tomcat6

### DIFF
--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -229,7 +229,7 @@ action :configure do
          -password pass:#{node['tomcat']['keystore_password']} \
          -out #{new_resource.keystore_file}
       EOH
-      notifies :restart, "service[tomcat]"
+      notifies :restart, "script[create_keystore-#{instance}]"
     end
 
     cookbook_file "#{new_resource.config_dir}/#{new_resource.ssl_cert_file}" do


### PR DESCRIPTION
Service can not restart in Rhel/Centos because the default is tomcat6 and not just "tomcat"

This is similar to the rest of the restarts in the providers file.

-Gary