### PR TITLE
Rhel instances fixes

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache 2.0'
 description      'Installs/Configures tomcat'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.17.3'
+version          '0.17.4'
 
 depends 'java'
 depends 'openssl'

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -107,6 +107,16 @@ action :configure do
         EOH
       end
     end
+    
+    # Copy origin tomcat startup script to instance one, since its name is hardcoded in the init one
+    if platform_family?('rhel')
+      file "/usr/sbin/#{instance}" do
+        content ::File.open("/usr/sbin/#{base_instance}").read
+        mode 0755
+        backup false
+        action :create_if_missing
+      end
+    end
   end
 
   # Even for the base instance, the OS package may not make this directory

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -60,12 +60,16 @@ action :configure do
         to "#{new_resource.base}"
       end
     end
-
-    # config_dir needs symlinks to the files we're not going to create
+    
+    # Copy config files from original config dir to our new config folder with new ownership
     ['catalina.policy', 'catalina.properties', 'context.xml',
      'tomcat-users.xml', 'web.xml'].each do |file|
-      link "#{new_resource.config_dir}/#{file}" do
-        to "#{node['tomcat']['config_dir']}/#{file}"
+      file "#{new_resource.config_dir}/#{file}" do
+        owner new_resource.user
+        group new_resource.group
+        mode 0660
+        content ::File.open("#{node['tomcat']['config_dir']}/#{file}").read
+        action :create
       end
     end
 

--- a/templates/default/tomcat_conf.erb
+++ b/templates/default/tomcat_conf.erb
@@ -1,0 +1,51 @@
+# System-wide configuration file for tomcat-jenkins services
+# This will be sourced by tomcat-jenkins and any secondary service
+# Values will be overridden by service-specific configuration
+# files in /etc/sysconfig
+#
+# Use this one to change default values for all services
+# Change the service specific ones to affect only one service
+# (see, for instance, /etc/sysconfig/tomcat-jenkins)
+#
+
+# Where your java installation lives
+#JAVA_HOME="/usr/lib/jvm/jre"
+
+# Where your tomcat-jenkins installation lives
+CATALINA_BASE="<%= @catalina_base %>"
+CATALINA_HOME="<%= @catalina_home %>"
+JASPER_HOME="<%= @catalina_home %>"
+CATALINA_TMPDIR="<%= @catalina_temp %>"
+
+# You can pass some parameters to java here if you wish to
+#JAVA_OPTS="-Xminf0.1 -Xmaxf0.3"
+
+# Use JAVA_OPTS to set java.library.path for libtcnative.so
+#JAVA_OPTS="-Djava.library.path=/usr/lib"
+
+# What user should run tomcat-jenkins
+TOMCAT_USER="<%= @user %>"
+
+# You can change your tomcat-jenkins locale here
+#LANG="en_US"
+
+# Run tomcat-jenkins under the Java Security Manager
+SECURITY_MANAGER="false"
+
+# Time to wait in seconds, before killing process
+SHUTDOWN_WAIT="30"
+
+# Whether to annoy the user with "attempting to shut down" messages or not
+SHUTDOWN_VERBOSE="false"
+
+# Set the TOMCAT_PID location
+CATALINA_PID="/var/run/<%= @instance %>.pid"
+
+# Connector port is 8080 for this tomcat-jenkins instance
+#CONNECTOR_PORT="8080"
+
+# If you wish to further customize your tomcat-jenkins environment,
+# put your own definitions here
+# (i.e. LD_LIBRARY_PATH for some jdbc drivers)
+
+TOMCAT_CFG="/etc/<%= @instance %>/<%= @instance %>.conf"


### PR DESCRIPTION
Trying to create additional instance of Tomcat under different user on CentOS (RHEL based distro) I had  several issues:
1. Some config files, like tomcat-users.xml is owned by tomcat in RPM and have 0660 access rights. The cookbook creates links to these files and not copies. In result, the instance running under another user cannot read these files (so it fails to start) and user cannot modify them.
2. Init script comes with RPM starts tomcat using special /usr/sbin/tomcat script (comes with RPM). Since all "$instance" which is tomcat by default is changed with "$newinstance" by provider, name of the script gets changed, however, the script with this name doesn't exist. In result, start-up fails.
3. The start-up script reads config file with name "/etc/$instance/$instance.conf" which doesn't exist for new instance. And if it cannot find this file, it reads default one, with environment variables for default instance. Therefore, additional instances use environment from default instance.

All of this make additional tomcats on RHEL unusable. Fixed all of that, and managed to run additional instance of tomcat under another user account on CentOS 6 with these changes.