### PR TITLE
`-keyalg "RSA"` is required for generating keystore file.

### DIFF
--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -207,7 +207,8 @@ action :configure do
          -keystore "#{new_resource.config_dir}/#{new_resource.keystore_file}" \
          -storepass "#{node['tomcat']['keystore_password']}" \
          -keypass "#{node['tomcat']['keystore_password']}" \
-         -dname "#{node['tomcat']['certificate_dn']}"
+         -dname "#{node['tomcat']['certificate_dn']}" \
+         -keyalg "RSA"
       EOH
       umask 0007
       creates "#{new_resource.config_dir}/#{new_resource.keystore_file}"


### PR DESCRIPTION
* I had SSL error with Tomcat7 on Ubuntu : ssl_error_no_cypher_overlap
* Adding `-keyalg "RSA"` fixes this issue.