### PR TITLE
Fix syntax error for foodcritic in .travis.yml, caused by previous commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ rvm:
   - 2.1
   - 2.2
 script:
-  - bundle exec foodcritic -f any -t ~FC005 ~FC023 .
+  - bundle exec foodcritic -f any -t "~FC005" -t "~FC023" .
   - bundle exec rubocop
   - bundle exec rspec --color --format progress


### PR DESCRIPTION
@tas50 please merge this in as well - last commit (52e0b9554d1ef4583d604383804e779ef3d053c5) caused an issue and you were too quick for me in merging it in..   :)

this is now fixed and build is passing on travis (though it doesn't run test-kitchen there)