### PR TITLE
Adding attribute for user-defined environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,31 @@ Users are defined by creating a `tomcat_users` data bag and placing [Encrypted D
 
 If you are a Chef Solo user the data bag items are not required to be encrypted and should not be.
 
+Defining Environment Variables
+------------------------------
+
+If your Tomcat application requires the usage of environment variables, you can define those into the `environment` attribute.
+
+This is a sample on how to set-up some environment variables:
+
+```javascript
+...
+"override_attributes": {
+  "tomcat": {
+    "environment": [
+      {
+        "VariableName": "LOCAL_HOME",
+        "VariableValue": "/usr/root"
+      },
+      {
+        "VariableName": "CONFIG_URL",
+        "VariableValue": "http://127.0.0.1/config"
+      }
+    ]
+  }
+  ...
+}
+```
 
 License & Authors
 -----------------

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Attributes
 * `node["tomcat"]["tomcat_auth"]` -
 * `node["tomcat"]["instances"]` - A dictionary defining additional tomcat instances to run.
 * `node["tomcat"]["run_base_instance"]` - Whether or not to run the "base" tomcat instance, default `true`.
+* `node["tomcat"]["environment"]` - Environment variables to be setup when starting Tomcat
 * `node["tomcat"]["user"]` -
 * `node["tomcat"]["group"]` -
 * `node["tomcat"]["home"]` -

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,6 +49,7 @@ default['tomcat']['loglevel'] = 'INFO'
 default['tomcat']['tomcat_auth'] = 'true'
 default['tomcat']['instances'] = {}
 default['tomcat']['run_base_instance'] = true
+default['tomcat']['environment'] = []
 default['tomcat']['packages'] = ["tomcat#{node['tomcat']['base_version']}"]
 default['tomcat']['deploy_manager_packages'] = ["tomcat#{node['tomcat']['base_version']}-admin"]
 default['tomcat']['ajp_packetsize'] = '8192'

--- a/templates/default/default_tomcat6.erb
+++ b/templates/default/default_tomcat6.erb
@@ -68,3 +68,8 @@ CATALINA_OPTS="<%= @catalina_options %>"
 
 # Endorse .jar files in this directory
 JAVA_ENDORSED_DIRS="<%= @endorsed_dir %>"
+
+# User-defined Environment variables
+<% @node["tomcat"]["environment"].each do |envvar| -%>
+<%= envvar['VariableName']-%>="<%= envvar['VariableValue']-%>"
+<% end -%>

--- a/templates/default/setenv.sh.erb
+++ b/templates/default/setenv.sh.erb
@@ -11,3 +11,8 @@ export CATALINA_BASE='<%= node["tomcat"]["base"] %>'
 export JAVA_OPTS='<%= node["tomcat"]["java_options"] %>'
 export CATALINA_OPTS='<%= node["tomcat"]["catalina_options"] %>'
 export CATALINA_PID='<%= node["tomcat"]["log_dir"] %>/catalina.pid'
+
+# User-defined Environment variables
+<% @node["tomcat"]["environment"].each do |envvar| -%>
+<%= envvar['VariableName']-%>='<%= envvar['VariableValue']-%>'
+<% end -%>

--- a/templates/default/sysconfig_tomcat6.erb
+++ b/templates/default/sysconfig_tomcat6.erb
@@ -63,3 +63,7 @@ JAVA_ENDORSED_DIRS="<%= @endorsed_dir %>"
 # put your own definitions here
 # (i.e. LD_LIBRARY_PATH for some jdbc drivers)
 
+# User-defined Environment variables
+<% @node["tomcat"]["environment"].each do |envvar| -%>
+<%= envvar['VariableName']-%>="<%= envvar['VariableValue']-%>"
+<% end -%>

--- a/templates/default/sysconfig_tomcat7.erb
+++ b/templates/default/sysconfig_tomcat7.erb
@@ -51,3 +51,7 @@ CATALINA_OPTS="<%= @catalina_options %>"
 # put your own definitions here
 # (i.e. LD_LIBRARY_PATH for some jdbc drivers)
 
+# User-defined Environment variables
+<% @node["tomcat"]["environment"].each do |envvar| -%>
+<%= envvar['VariableName']-%>="<%= envvar['VariableValue']-%>"
+<% end -%>


### PR DESCRIPTION
This change will allow the generation of user-defined environment variables that are set before Tomcat is started.
Usage would be:

        envs = []
        envs.push({'VariableName' => 'LOCAL_HOME', 'VariableValue' => '/usr/root'})
        envs.push({'VariableName' => 'CONFIG_URL', 'VariableValue' => 'http://127.0.0.1/config'})
        node.default['tomcat']['environment'] = envs