### PR TITLE
change version specific rules for epel support

### DIFF
--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -35,7 +35,7 @@
   <% end -%>
   <!-- Prevent memory leaks due to use of particular java/javax APIs-->
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
-  <% if node['tomcat']['base_version'].to_i < 7 -%>
+  <% if node['tomcat']['base_version'].to_i.between?(1, 6) -%>
   <!-- JMX Support for the Tomcat server. Documentation at /docs/non-existent.html -->
   <Listener className="org.apache.catalina.mbeans.ServerLifecycleListener" />
   <% end -%>
@@ -167,7 +167,7 @@
        -->
       <Host name="localhost"  appBase="webapps"
             unpackWARs="true" autoDeploy="true"
-            <% if node['tomcat']['base_version'].to_i < 7 -%>
+            <% if node['tomcat']['base_version'].to_i.between?(1, 6) -%>
             xmlValidation="false" xmlNamespaceAware="false"
             <% end -%>
             >


### PR DESCRIPTION
minor change to support epel tomcat which has no version specified in the package name. < 7 results in epel tomcat (7) not starting
Setting the version attribute to "" after this change results in a working tomcat install