### PR TITLE
Fix derived attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,10 @@
 # limitations under the License.
 
 default['tomcat']['base_version'] = 6
-default['tomcat']['base_instance'] = "tomcat#{node['tomcat']['base_version']}"
+# default['tomcat']['base_instance'] = # see libraries/helpers.rb
+# default['tomcat']['packages'] = # see libraries/helpers.rb
+# default['tomcat']['deploy_manager_packages'] = # see libraries/helpers.rb
+
 default['tomcat']['port'] = 8080
 default['tomcat']['proxy_port'] = nil
 default['tomcat']['ssl_port'] = 8443
@@ -50,90 +53,22 @@ default['tomcat']['tomcat_auth'] = 'true'
 default['tomcat']['instances'] = {}
 default['tomcat']['run_base_instance'] = true
 default['tomcat']['environment'] = []
-default['tomcat']['packages'] = ["tomcat#{node['tomcat']['base_version']}"]
-default['tomcat']['deploy_manager_packages'] = ["tomcat#{node['tomcat']['base_version']}-admin"]
 default['tomcat']['ajp_packetsize'] = '8192'
 default['tomcat']['uriencoding'] = 'UTF-8'
-case node['platform_family']
 
-when 'rhel', 'fedora'
-  suffix = node['tomcat']['base_version'].to_i < 7 ? node['tomcat']['base_version'] : ''
-
-  default['tomcat']['base_instance'] = "tomcat#{suffix}"
-  default['tomcat']['user'] = 'tomcat'
-  default['tomcat']['group'] = 'tomcat'
-  default['tomcat']['home'] = "/usr/share/tomcat#{suffix}"
-  default['tomcat']['base'] = "/usr/share/tomcat#{suffix}"
-  default['tomcat']['config_dir'] = "/etc/tomcat#{suffix}"
-  default['tomcat']['log_dir'] = "/var/log/tomcat#{suffix}"
-  default['tomcat']['tmp_dir'] = "/var/cache/tomcat#{suffix}/temp"
-  default['tomcat']['work_dir'] = "/var/cache/tomcat#{suffix}/work"
-  default['tomcat']['context_dir'] = "#{node['tomcat']['config_dir']}/Catalina/localhost"
-  default['tomcat']['webapp_dir'] = "/var/lib/tomcat#{suffix}/webapps"
-  default['tomcat']['keytool'] = 'keytool'
-  default['tomcat']['lib_dir'] = "#{node['tomcat']['home']}/lib"
-  default['tomcat']['endorsed_dir'] = "#{node['tomcat']['lib_dir']}/endorsed"
-  default['tomcat']['packages'] = ["tomcat#{suffix}"]
-  default['tomcat']['deploy_manager_packages'] = ["tomcat#{suffix}-admin-webapps"]
-when 'debian'
-  default['tomcat']['user'] = "tomcat#{node['tomcat']['base_version']}"
-  default['tomcat']['group'] = "tomcat#{node['tomcat']['base_version']}"
-  default['tomcat']['home'] = "/usr/share/tomcat#{node['tomcat']['base_version']}"
-  default['tomcat']['base'] = "/var/lib/tomcat#{node['tomcat']['base_version']}"
-  default['tomcat']['config_dir'] = "/etc/tomcat#{node['tomcat']['base_version']}"
-  default['tomcat']['log_dir'] = "/var/log/tomcat#{node['tomcat']['base_version']}"
-  default['tomcat']['tmp_dir'] = "/tmp/tomcat#{node['tomcat']['base_version']}-tmp"
-  default['tomcat']['work_dir'] = "/var/cache/tomcat#{node['tomcat']['base_version']}"
-  default['tomcat']['context_dir'] = "#{node['tomcat']['config_dir']}/Catalina/localhost"
-  default['tomcat']['webapp_dir'] = "/var/lib/tomcat#{node['tomcat']['base_version']}/webapps"
-  default['tomcat']['keytool'] = 'keytool'
-  default['tomcat']['lib_dir'] = "#{node['tomcat']['home']}/lib"
-  default['tomcat']['endorsed_dir'] = "#{node['tomcat']['lib_dir']}/endorsed"
-when 'smartos'
-  default['tomcat']['user'] = 'tomcat'
-  default['tomcat']['group'] = 'tomcat'
-  default['tomcat']['home'] = '/opt/local/share/tomcat'
-  default['tomcat']['base'] = '/opt/local/share/tomcat'
-  default['tomcat']['config_dir'] = '/opt/local/share/tomcat/conf'
-  default['tomcat']['log_dir'] = '/opt/local/share/tomcat/logs'
-  default['tomcat']['tmp_dir'] = '/opt/local/share/tomcat/temp'
-  default['tomcat']['work_dir'] = '/opt/local/share/tomcat/work'
-  default['tomcat']['context_dir'] = "#{node['tomcat']['config_dir']}/Catalina/localhost"
-  default['tomcat']['webapp_dir'] = '/opt/local/share/tomcat/webapps'
-  default['tomcat']['keytool'] = '/opt/local/bin/keytool'
-  default['tomcat']['lib_dir'] = "#{node['tomcat']['home']}/lib"
-  default['tomcat']['endorsed_dir'] = "#{node['tomcat']['home']}/lib/endorsed"
-  default['tomcat']['packages'] = ['apache-tomcat']
-  default['tomcat']['deploy_manager_packages'] = []
-when 'suse'
-  default['tomcat']['base_instance'] = 'tomcat'
-  default['tomcat']['user'] = 'tomcat'
-  default['tomcat']['group'] = 'tomcat'
-  default['tomcat']['home'] = '/usr/share/tomcat'
-  default['tomcat']['base'] = '/usr/share/tomcat'
-  default['tomcat']['config_dir'] = '/etc/tomcat'
-  default['tomcat']['log_dir'] = '/var/log/tomcat'
-  default['tomcat']['tmp_dir'] = '/var/cache/tomcat/temp'
-  default['tomcat']['work_dir'] = '/var/cache/tomcat/work'
-  default['tomcat']['context_dir'] = "#{node['tomcat']['config_dir']}/Catalina/localhost"
-  default['tomcat']['webapp_dir'] = '/srv/tomcat/webapps'
-  default['tomcat']['keytool'] = 'keytool'
-  default['tomcat']['lib_dir'] = "#{node['tomcat']['home']}/lib"
-  default['tomcat']['endorsed_dir'] = "#{node['tomcat']['lib_dir']}/endorsed"
-  default['tomcat']['packages'] = ['tomcat']
-  default['tomcat']['deploy_manager_packages'] = ['tomcat-admin-webapps']
-else
-  default['tomcat']['user'] = "tomcat#{node['tomcat']['base_version']}"
-  default['tomcat']['group'] = "tomcat#{node['tomcat']['base_version']}"
-  default['tomcat']['home'] = "/usr/share/tomcat#{node['tomcat']['base_version']}"
-  default['tomcat']['base'] = "/var/lib/tomcat#{node['tomcat']['base_version']}"
-  default['tomcat']['config_dir'] = "/etc/tomcat#{node['tomcat']['base_version']}"
-  default['tomcat']['log_dir'] = "/var/log/tomcat#{node['tomcat']['base_version']}"
-  default['tomcat']['tmp_dir'] = "/tmp/tomcat#{node['tomcat']['base_version']}-tmp"
-  default['tomcat']['work_dir'] = "/var/cache/tomcat#{node['tomcat']['base_version']}"
-  default['tomcat']['context_dir'] = "#{node['tomcat']['config_dir']}/Catalina/localhost"
-  default['tomcat']['webapp_dir'] = "/var/lib/tomcat#{node['tomcat']['base_version']}/webapps"
-  default['tomcat']['keytool'] = 'keytool'
-  default['tomcat']['lib_dir'] = "#{node['tomcat']['home']}/lib"
-  default['tomcat']['endorsed_dir'] = "#{node['tomcat']['lib_dir']}/endorsed"
-end
+# default['tomcat']['base_instance'] = # see libraries/helpers.rb
+# default['tomcat']['user'] = # see libraries/helpers.rb
+# default['tomcat']['group'] = # see libraries/helpers.rb
+# default['tomcat']['home'] = # see libraries/helpers.rb
+# default['tomcat']['base'] = # see libraries/helpers.rb
+# default['tomcat']['config_dir'] = # see libraries/helpers.rb
+# default['tomcat']['log_dir'] = # see libraries/helpers.rb
+# default['tomcat']['tmp_dir'] = # see libraries/helpers.rb
+# default['tomcat']['work_dir'] = # see libraries/helpers.rb
+# default['tomcat']['context_dir'] = # see libraries/helpers.rb
+# default['tomcat']['webapp_dir'] = # see libraries/helpers.rb
+# default['tomcat']['keytool'] = # see libraries/helpers.rb
+# default['tomcat']['lib_dir'] = # see libraries/helpers.rb
+# default['tomcat']['endorsed_dir'] = # see libraries/helpers.rb
+# default['tomcat']['packages'] = # see libraries/helpers.rb
+# default['tomcat']['deploy_manager_packages'] = # see libraries/helpers.rb

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,98 @@
+# This method should be used at the start of every recipe that would need to use the below attributes,
+# in an attempt to solve #89, #102, #129, #148 and #174.
+# Any cookbook attribute that uses the value of another attribute to calculate its own value (derived)
+# should be included in this method, so that the calculation of the value takes place at runtime of the recipe.
+# The reason is simple: Due to how attribute precedence works in Chef, when an attribute is overriden, it is not always
+# the case that the derived attributes will use the correct value of the original attribute to calculate their own.
+# This depends on how the attribute has been overriden (cookbook attributes, role, environment, etc.)
+# See [this](https://christinemdraper.wordpress.com/2014/10/06/avoiding-the-possible-pitfalls-of-derived-attributes/) for a detailed explanation.
+
+def set_derived_vars
+  case node['platform_family']
+  when 'rhel', 'fedora'
+    suffix = node['tomcat']['base_version'].to_i < 7 ? node['tomcat']['base_version'] : ''
+
+    node.default_unless['tomcat']['base_instance'] = "tomcat#{suffix}"
+    node.default_unless['tomcat']['user'] = 'tomcat'
+    node.default_unless['tomcat']['group'] = 'tomcat'
+    node.default_unless['tomcat']['home'] = "/usr/share/tomcat#{suffix}"
+    node.default_unless['tomcat']['base'] = "/usr/share/tomcat#{suffix}"
+    node.default_unless['tomcat']['config_dir'] = "/etc/tomcat#{suffix}"
+    node.default_unless['tomcat']['log_dir'] = "/var/log/tomcat#{suffix}"
+    node.default_unless['tomcat']['tmp_dir'] = "/var/cache/tomcat#{suffix}/temp"
+    node.default_unless['tomcat']['work_dir'] = "/var/cache/tomcat#{suffix}/work"
+    node.default_unless['tomcat']['context_dir'] = "#{node['tomcat']['config_dir']}/Catalina/localhost"
+    node.default_unless['tomcat']['webapp_dir'] = "/var/lib/tomcat#{suffix}/webapps"
+    node.default_unless['tomcat']['keytool'] = 'keytool'
+    node.default_unless['tomcat']['lib_dir'] = "#{node['tomcat']['home']}/lib"
+    node.default_unless['tomcat']['endorsed_dir'] = "#{node['tomcat']['lib_dir']}/endorsed"
+    node.default_unless['tomcat']['packages'] = ["tomcat#{suffix}"]
+    node.default_unless['tomcat']['deploy_manager_packages'] = ["tomcat#{suffix}-admin-webapps"]
+  when 'debian'
+    node.default_unless['tomcat']['user'] = "tomcat#{node['tomcat']['base_version']}"
+    node.default_unless['tomcat']['group'] = "tomcat#{node['tomcat']['base_version']}"
+    node.default_unless['tomcat']['home'] = "/usr/share/tomcat#{node['tomcat']['base_version']}"
+    node.default_unless['tomcat']['base'] = "/var/lib/tomcat#{node['tomcat']['base_version']}"
+    node.default_unless['tomcat']['config_dir'] = "/etc/tomcat#{node['tomcat']['base_version']}"
+    node.default_unless['tomcat']['log_dir'] = "/var/log/tomcat#{node['tomcat']['base_version']}"
+    node.default_unless['tomcat']['tmp_dir'] = "/tmp/tomcat#{node['tomcat']['base_version']}-tmp"
+    node.default_unless['tomcat']['work_dir'] = "/var/cache/tomcat#{node['tomcat']['base_version']}"
+    node.default_unless['tomcat']['context_dir'] = "#{node['tomcat']['config_dir']}/Catalina/localhost"
+    node.default_unless['tomcat']['webapp_dir'] = "/var/lib/tomcat#{node['tomcat']['base_version']}/webapps"
+    node.default_unless['tomcat']['keytool'] = 'keytool'
+    node.default_unless['tomcat']['lib_dir'] = "#{node['tomcat']['home']}/lib"
+    node.default_unless['tomcat']['endorsed_dir'] = "#{node['tomcat']['lib_dir']}/endorsed"
+  when 'smartos'
+    node.default_unless['tomcat']['user'] = 'tomcat'
+    node.default_unless['tomcat']['group'] = 'tomcat'
+    node.default_unless['tomcat']['home'] = '/opt/local/share/tomcat'
+    node.default_unless['tomcat']['base'] = '/opt/local/share/tomcat'
+    node.default_unless['tomcat']['config_dir'] = '/opt/local/share/tomcat/conf'
+    node.default_unless['tomcat']['log_dir'] = '/opt/local/share/tomcat/logs'
+    node.default_unless['tomcat']['tmp_dir'] = '/opt/local/share/tomcat/temp'
+    node.default_unless['tomcat']['work_dir'] = '/opt/local/share/tomcat/work'
+    node.default_unless['tomcat']['context_dir'] = "#{node['tomcat']['config_dir']}/Catalina/localhost"
+    node.default_unless['tomcat']['webapp_dir'] = '/opt/local/share/tomcat/webapps'
+    node.default_unless['tomcat']['keytool'] = '/opt/local/bin/keytool'
+    node.default_unless['tomcat']['lib_dir'] = "#{node['tomcat']['home']}/lib"
+    node.default_unless['tomcat']['endorsed_dir'] = "#{node['tomcat']['home']}/lib/endorsed"
+    node.default_unless['tomcat']['packages'] = ['apache-tomcat']
+    node.default_unless['tomcat']['deploy_manager_packages'] = []
+  when 'suse'
+    node.default_unless['tomcat']['base_instance'] = 'tomcat'
+    node.default_unless['tomcat']['user'] = 'tomcat'
+    node.default_unless['tomcat']['group'] = 'tomcat'
+    node.default_unless['tomcat']['home'] = '/usr/share/tomcat'
+    node.default_unless['tomcat']['base'] = '/usr/share/tomcat'
+    node.default_unless['tomcat']['config_dir'] = '/etc/tomcat'
+    node.default_unless['tomcat']['log_dir'] = '/var/log/tomcat'
+    node.default_unless['tomcat']['tmp_dir'] = '/var/cache/tomcat/temp'
+    node.default_unless['tomcat']['work_dir'] = '/var/cache/tomcat/work'
+    node.default_unless['tomcat']['context_dir'] = "#{node['tomcat']['config_dir']}/Catalina/localhost"
+    node.default_unless['tomcat']['webapp_dir'] = '/srv/tomcat/webapps'
+    node.default_unless['tomcat']['keytool'] = 'keytool'
+    node.default_unless['tomcat']['lib_dir'] = "#{node['tomcat']['home']}/lib"
+    node.default_unless['tomcat']['endorsed_dir'] = "#{node['tomcat']['lib_dir']}/endorsed"
+    node.default_unless['tomcat']['packages'] = ['tomcat']
+    node.default_unless['tomcat']['deploy_manager_packages'] = ['tomcat-admin-webapps']
+  else
+    node.default_unless['tomcat']['user'] = "tomcat#{node['tomcat']['base_version']}"
+    node.default_unless['tomcat']['group'] = "tomcat#{node['tomcat']['base_version']}"
+    node.default_unless['tomcat']['home'] = "/usr/share/tomcat#{node['tomcat']['base_version']}"
+    node.default_unless['tomcat']['base'] = "/var/lib/tomcat#{node['tomcat']['base_version']}"
+    node.default_unless['tomcat']['config_dir'] = "/etc/tomcat#{node['tomcat']['base_version']}"
+    node.default_unless['tomcat']['log_dir'] = "/var/log/tomcat#{node['tomcat']['base_version']}"
+    node.default_unless['tomcat']['tmp_dir'] = "/tmp/tomcat#{node['tomcat']['base_version']}-tmp"
+    node.default_unless['tomcat']['work_dir'] = "/var/cache/tomcat#{node['tomcat']['base_version']}"
+    node.default_unless['tomcat']['context_dir'] = "#{node['tomcat']['config_dir']}/Catalina/localhost"
+    node.default_unless['tomcat']['webapp_dir'] = "/var/lib/tomcat#{node['tomcat']['base_version']}/webapps"
+    node.default_unless['tomcat']['keytool'] = 'keytool'
+    node.default_unless['tomcat']['lib_dir'] = "#{node['tomcat']['home']}/lib"
+    node.default_unless['tomcat']['endorsed_dir'] = "#{node['tomcat']['lib_dir']}/endorsed"
+  end
+
+  # finally, set these, if they've not been set already
+  node.default_unless['tomcat']['base_instance'] = "tomcat#{node['tomcat']['base_version']}"
+  node.default_unless['tomcat']['packages'] = ["tomcat#{node['tomcat']['base_version']}"]
+  node.default_unless['tomcat']['deploy_manager_packages'] = ["tomcat#{node['tomcat']['base_version']}-admin"]
+end

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -58,7 +58,7 @@ action :configure do
     end
 
     # Don't make a separate home, just link to base
-    if new_resource.home != new_resource.base
+    if new_resource.home != new_resource.base # ~FC023
       link new_resource.home do
         to new_resource.base
       end
@@ -272,10 +272,9 @@ action :configure do
     end
   end
 
-  unless new_resource.truststore_file.nil?
-    cookbook_file "#{new_resource.config_dir}/#{new_resource.truststore_file}" do
-      mode '0644'
-    end
+  cookbook_file "#{new_resource.config_dir}/#{new_resource.truststore_file}" do
+    mode '0644'
+    not_if { new_resource.truststore_file.nil? }
   end
 
   new_resource.updated_by_last_action(true)

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -1,4 +1,7 @@
 action :configure do
+  # first of all set derived variables
+  set_derived_vars
+
   base_instance = node['tomcat']['base_instance']
 
   # Set defaults for resource attributes from node attributes. We can't do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,12 +29,16 @@ if node['tomcat']['base_version'].to_i == 7
   end
 end
 
-package node['tomcat']['packages'] do
-  action :install
+node['tomcat']['packages'].each do |pkg|
+  package pkg do
+    action :install
+  end
 end
 
-package node['tomcat']['deploy_manager_packages'] do
-  action :install
+node['tomcat']['deploy_manager_packages'].each do |pkg|
+  package pkg do
+    action :install
+  end
 end
 
 unless node['tomcat']['deploy_manager_apps']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,6 +20,8 @@
 # required for the secure_password method from the openssl cookbook
 ::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
 
+set_derived_vars
+
 # RHEL systems prior to 7 need the EPEL repository setup
 if node['tomcat']['base_version'].to_i == 7
   if platform_family?('rhel') && node['platform_version'].to_i < 7

--- a/recipes/users.rb
+++ b/recipes/users.rb
@@ -19,6 +19,8 @@
 # limitations under the License.
 #
 
+set_derived_vars
+
 template "#{node['tomcat']['config_dir']}/tomcat-users.xml" do
   source 'tomcat-users.xml.erb'
   owner 'root'


### PR DESCRIPTION
This PR should address a number of issues that stem from some derived attributes having 'wrong' values. This has been reported to be the cause for issues #89, #102, #129, #148, #174 (at least). 

Basic idea is that when you override e.g. `base_version` in your own cookbook attributes (as opposed to a role or env, for example) any other attribute of this cookbook that uses this attribute's value will end up having an unexpected / wrong value due to the way attribute precedence works in chef. 
This has been well documented especially in #102.  

The PR also includes some minor fixes for regressions that broke the test kitchen and foodcritic runs. 

@tas50: Given the number of issues it fixes, I believe it's worth a look for merging in. 