### PR TITLE
create_keystore-#{instance} needs to start service[#{instance}]

### DIFF
--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -251,7 +251,7 @@ action :configure do
          -password pass:#{node['tomcat']['keystore_password']} \
          -out #{new_resource.keystore_file}
       EOH
-      notifies :restart, 'service[tomcat]'
+      notifies :restart, "service[#{instance}]"
     end
 
     cookbook_file "#{new_resource.config_dir}/#{new_resource.ssl_cert_file}" do


### PR DESCRIPTION
the recipe creates a service under the variable name #{instance} -- which might be the string 'tomcat' but often isn't. This change causes the service name used for the restart after generating a key to match the name of the service created but the recipe.