### PR TITLE
Remove hardcoded Java option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Installs and configures Tomcat, Java servlet engine and webserver version 6 and 
 - `node['tomcat']['ajp_listen_ip']` - If set, the network address used by Tomcat's AJP connector, default nil.
 - `node['tomcat']['shutdown_port']` - The network port used by Tomcat to listen for shutdown requests, default `8005`.
 - `node['tomcat']['catalina_options']` - Extra options to pass to the JVM only during start and run commands, default "".
-- `node['tomcat']['java_options']` - Extra options to pass to the JVM, default `-Xmx128M -Djava.awt.headless=true`.
+- `node['tomcat']['java_options']` - Extra options to pass to the JVM, default `-Xmx128M -Djava.awt.headless=true -XX:+UseConcMarkSweepGC`.
 - `node['tomcat']['use_security_manager']` - Run Tomcat under the Java Security Manager, default `false`.
 - `node['tomcat']['loglevel']` - Level for default Tomcat's logs, default `INFO`.
 - `node['tomcat']['deploy_manager_apps']` - whether to deploy manager apps, default `true`.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,7 +30,7 @@ default['tomcat']['ajp_redirect_port'] = nil
 default['tomcat']['ajp_listen_ip'] = nil
 default['tomcat']['shutdown_port'] = 8005
 default['tomcat']['catalina_options'] = ''
-default['tomcat']['java_options'] = '-Xmx128M -Djava.awt.headless=true'
+default['tomcat']['java_options'] = '-Xmx128M -Djava.awt.headless=true -XX:+UseConcMarkSweepGC'
 default['tomcat']['use_security_manager'] = false
 default['tomcat']['authbind'] = 'no'
 default['tomcat']['deploy_manager_apps'] = true

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -166,7 +166,7 @@ action :configure do
     end
   else
     template "/etc/default/#{instance}" do
-      source 'default_tomcat6.erb'
+      source 'default_tomcat.erb'
       variables(
         user: new_resource.user,
         group: new_resource.group,

--- a/templates/default/default_tomcat.erb
+++ b/templates/default/default_tomcat.erb
@@ -31,27 +31,8 @@ CATALINA_BASE=<%= @base %>
 # options (-Djava.awt.headless=true -Xmx128m) will be used.
 JAVA_OPTS="<%= @java_options %>"
 
-# Use a CMS garbage collector for improved response time
-JAVA_OPTS="${JAVA_OPTS} -XX:+UseConcMarkSweepGC"
-
-# When using the CMS garbage collector, you should enable the following option
-# if you run Tomcat on a machine with exactly one CPU chip that contains one
-# or two cores.
-#JAVA_OPTS="$JAVA_OPTS -XX:+CMSIncrementalMode"
-
-# To enable remote debugging uncomment the following line.
-# You will then be able to use a java debugger on port 8000.
-#JAVA_OPTS="${JAVA_OPTS} -Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n"
-
-# Java compiler to use for translating JavaServer Pages (JSPs). You can use all
-# compilers that are accepted by Ant's build.compiler property.
-#JSP_COMPILER=javac
-
 # Use the Java security manager? (yes/no, default: no)
 TOMCAT<%= node['tomcat']['base_version'] %>_SECURITY=<%= @use_security_manager ? "yes" : "no" %>
-
-# Number of days to keep logfiles in /var/log/tomcat6. Default is 14 days.
-#LOGFILE_DAYS=14
 
 # Location of the JVM temporary directory
 # WARNING: This directory will be destroyed and recreated at every startup !


### PR DESCRIPTION
The template `default_tomcat6.erb` enforced the use of CMS garbage
collection on all distros that set JAVA_OPTS in /etc/default/tomcat#.
This eliminates the ability to use alternative garbage collectors like
Parallel or G1.

* Remove concatenation of -XX:+UseConcMarkSweepGC from template
* Cleanup commented out lines
* Add -XX:+UseConcMarkSweepGC to default attribute
* Update README
* Rename template to reflect it affecting all versions of Tomcat

Resolves #196 