### PR TITLE
Let Net::HTTP use proxy

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -45,7 +45,8 @@ end
 # we have to do this since the sha256 chef expects isn't hosted
 def fetch_checksum
   uri = URI.join(sha1_base_path, "tomcat-#{major_version}/v#{version}/bin/apache-tomcat-#{version}.tar.gz.sha1")
-  response = Net::HTTP.get_response(uri)
+  request = Net::HTTP.new(uri.host, uri.port)
+  response = request.get(uri)
   if response.code != '200'
     Chef::Log.fatal("Fetching the Tomcat tarball checksum at #{uri} resulted in an error #{response.code}")
     raise


### PR DESCRIPTION
I found that the checksum file download was failing in my environment because we require a proxy for outbound internet traffic. 

Interestingly enough, Net::HTTP does not respect the http_proxy environment variable unless it is called as an object rather than using the get_response function directly. (See this [blog post](https://www.jethrocarr.com/2014/08/14/ruby-nethttp-proxies/) that pointed me in the right direction)

This change replaces the direct function call so that proxy settings are respected.