### PR TITLE
Cookbook breaks when installing old Tomcat versions due to missing .sha1 files.

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -42,10 +42,10 @@ action_class do
     end
   end
 
-  # fetch the sha1 checksum from the mirrors
-  # we have to do this since the sha256 chef expects isn't hosted
+  # fetch the md5 checksum from the mirrors
+  # we have to do this since the md5 chef expects isn't hosted
   def fetch_checksum
-    uri = URI.join(new_resource.sha1_base_path, "tomcat-#{major_version}/v#{new_resource.version}/bin/apache-tomcat-#{new_resource.version}.tar.gz.sha1")
+    uri = URI.join(new_resource.sha1_base_path, "tomcat-#{major_version}/v#{new_resource.version}/bin/apache-tomcat-#{new_resource.version}.tar.gz.md5")
     request = Net::HTTP.new(uri.host, uri.port)
     response = request.get(uri)
     if response.code != '200'
@@ -62,7 +62,7 @@ action_class do
   # return true if they match. Append .bad to the cached copy to prevent using it next time
   def validate_checksum(file_to_check)
     desired = fetch_checksum
-    actual = Digest::SHA1.hexdigest(::File.read(file_to_check))
+    actual = Digest::MD5.hexdigest(::File.read(file_to_check))
 
     if desired == actual
       true


### PR DESCRIPTION
Hi,

Older Tomcat releases do not have accompanying .sha1 checksum files, only .md5, therefore older versions of Tomcat on the Apache mirrors fail to install. Below is when I was trying to install `7.0.42`.

```
    ------------
    remote_file[apache 7.0.42 tarball] (/var/chef/cache/cookbooks/tomcat/resources/install.rb line 92) had an error: RuntimeError:

    Cookbook Trace:
    ---------------
    /var/chef/cache/cookbooks/tomcat/resources/install.rb:53:in `fetch_checksum'
    /var/chef/cache/cookbooks/tomcat/resources/install.rb:64:in `validate_checksum'
    /var/chef/cache/cookbooks/tomcat/resources/install.rb:95:in `block (3 levels) in class_from_file'
    /var/chef/cache/cookbooks/compat_resource/files/lib/chef_compat/copied_from_chef/chef/provider.rb:123:in `compile_and_converge_action'

    Resource Declaration:
    ---------------------
    # In /var/chef/cache/cookbooks/vw-tomcat/recipes/default.rb

      8: tomcat_install 'helloworld' do
      9:   version node['tomcat']['version']
     10: end
     11:

    Compiled Resource:
    ------------------
    # Declared in /var/chef/cache/cookbooks/vw-tomcat/recipes/default.rb:8:in `from_file'

    tomcat_install("helloworld") do
      action [:install]
      retries 0
      retry_delay 2
      default_guard_interpreter :default
      declared_type :tomcat_install
      cookbook_name "vw-tomcat"
      recipe_name "default"
      version "7.0.42"
      tarball_base_path "http://archive.apache.org/dist/tomcat/"
      instance_name "helloworld"
      exclude_examples true
      exclude_docs true
      sha1_base_path "http://archive.apache.org/dist/tomcat/"
    end


Running handlers:
Running handlers complete
Chef Client failed. 1 resources updated in 24 seconds
```

As you can see there are only .md5 files for this release here: http://archive.apache.org/dist/tomcat/tomcat-6/v6.0.14/bin/

Since current releases are being packaged still with md5 checksums attached is a PR to use md5 vs. sha1 which will ensure that this cookbook will install older versions of Tomcat in addition to still supporting current releases.