### PR TITLE
Fixes #236

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -28,7 +28,7 @@ action_class do
   def extraction_command
     cmd = "tar -xzf #{Chef::Config['file_cache_path']}/apache-tomcat-#{new_resource.version}.tar.gz -C #{full_install_path} --strip-components=1"
     cmd << " --exclude='*webapps/examples*'" if new_resource.exclude_examples
-    cmd << " --exclude='*webapps/ROOT/*'" if new_resource.exclude_examples
+    cmd << " --exclude='*webapps/ROOT*'" if new_resource.exclude_examples
     cmd << " --exclude='*webapps/docs*'" if new_resource.exclude_docs
     cmd << " --exclude='*webapps/manager*'" if new_resource.exclude_manager
     cmd << " --exclude='*webapps/host-manager*'" if new_resource.exclude_hostmanager


### PR DESCRIPTION
I believe this was probably the intended behaviour anyway (i.e. I'm not sure if the extra `/` was intentional, looking at the other exclude patterns). Keeping an empty ROOT dir doesn't really offer much anyway (unless not being able to deploy the ROOT app is a feature, for some reason?)