### PR TITLE
Add support for specifying a complete URL for tomcat tarball

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -9,3 +9,4 @@ group :integration do
   cookbook 'java', '>= 1.36'
 end
 
+cookbook 'test', path: 'test/cookbooks/test'

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ tomcat_install installs an instance of the tomcat binary direct from Apache's mi
 - `install_path`: Full path to the install directory. Default: /opt/tomcat_INSTANCENAME_VERSION
 - `tarball_base_path`: The base path to the apache mirror containing the tarballs. Default: '<http://archive.apache.org/dist/tomcat/>'
 - `checksum_base_path`: The base path to the apache mirror containing the md5 file. Default: '<http://archive.apache.org/dist/tomcat/>'
-- `tarball_uri`: The complete path to the tarball. If mentioned would override (`tarball_base_path` and `checksum_base_path`). checksum will be loaded from "#{tarball_uri}.md5". This attribute is useful, if you are hosting tomcat tarballs from artifact repositories such as nexus.
+- `tarball_uri`: The complete path to the tarball. If specified would override (`tarball_base_path` and `checksum_base_path`). checksum will be loaded from "#{tarball_uri}.md5". This attribute is useful, if you are hosting tomcat tarballs from artifact repositories such as nexus.
 - `exclude_docs`: Exclude ./webapps/docs from installation. Default true.
 - `exclude_examples`: Exclude ./webapps/examples from installation. Default true.
 - `exclude_manager`: Exclude ./webapps/manager from installation. Default: false.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ tomcat_install installs an instance of the tomcat binary direct from Apache's mi
 - `install_path`: Full path to the install directory. Default: /opt/tomcat_INSTANCENAME_VERSION
 - `tarball_base_path`: The base path to the apache mirror containing the tarballs. Default: '<http://archive.apache.org/dist/tomcat/>'
 - `checksum_base_path`: The base path to the apache mirror containing the md5 file. Default: '<http://archive.apache.org/dist/tomcat/>'
+- `tarball_uri`: The complete path to the tarball. If mentioned would override (`tarball_base_path` and `checksum_base_path`). checksum will be loaded from "#{tarball_uri}.md5". This attribute is useful, if you are hosting tomcat tarballs from artifact repositories such as nexus.
 - `exclude_docs`: Exclude ./webapps/docs from installation. Default true.
 - `exclude_examples`: Exclude ./webapps/examples from installation. Default true.
 - `exclude_manager`: Exclude ./webapps/manager from installation. Default: false.

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -53,7 +53,7 @@ action_class do
             URI.join(new_resource.checksum_base_path, "tomcat-#{major_version}/v#{new_resource.version}/bin/apache-tomcat-#{new_resource.version}.tar.gz.md5")
           else
             URI("#{new_resource.tarball_uri}.md5")
-    end
+          end
     request = Net::HTTP.new(uri.host, uri.port)
     response = request.get(uri)
     if response.code != '200'

--- a/test/integration/multi-instance/default_spec.rb
+++ b/test/integration/multi-instance/default_spec.rb
@@ -9,11 +9,11 @@ describe file('/opt/special/tomcat_docs_7_0_42/LICENSE') do
 end
 
 describe command('curl http://localhost:8081/sample/') do
-  its('stdout') { should match /Hello, World/ }
+  its('stdout') { should match(/Hello, World/) }
 end
 
 describe command('curl http://localhost:8080/') do
-  its('stdout') { should match /successfully installed Tomcat/ }
+  its('stdout') { should match(/successfully installed Tomcat/) }
 end
 
 %w(tomcat_helloworld tomcat_docs).each do |service_name|


### PR DESCRIPTION
### Description

Adds support specifying complete URL for tomcat tarbal to install

### Issues Resolved

#253 

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD.
- [ ] New functionality includes testing. 
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


Enable support for specifying complete tarball URL for tomcat