### PR TITLE
WIP: support non-system default init systems with proper restarts

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -87,7 +87,7 @@ platforms:
     image: opensuse:13.2
     pid_one_command: /bin/systemd
     intermediate_instructions:
-      - RUN zypper --non-interactive install aaa_base
+      - RUN zypper --non-interactive install aaa_base perl-Getopt-Long-Descriptive
 
 suites:
 - name: multi_instance

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -86,6 +86,8 @@ platforms:
   driver:
     image: opensuse:13.2
     pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN zypper --non-interactive install aaa_base
 
 suites:
 - name: multi_instance

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -52,14 +52,14 @@ platforms:
     platform: rhel
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
-      - RUN yum -y install lsof which
+      - RUN yum -y install lsof which systemd-sysv initscripts
 
 - name: fedora-23
   driver:
     image: fedora:23
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
-      - RUN dnf -y install yum which
+      - RUN dnf -y install yum which systemd-sysv initscripts
 
 - name: ubuntu-12.04
   driver:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ addons:
     packages:
       - chefdk
 
+# Don't `bundle install` which takes about 1.5 mins
+install: echo "skip bundle install"
+
 branches:
   only:
   - master

--- a/libraries/tomcat.rb
+++ b/libraries/tomcat.rb
@@ -31,3 +31,11 @@ def ensure_catalina_base
     new_resource.env_vars.unshift('CATALINA_BASE' => derived_install_path)
   end
 end
+
+# choose the right platform init class
+def platform_sysv_init_class
+  value_for_platform_family(
+    'debian' => Chef::Provider::Service::Init::Debian,
+    'default' => Chef::Provider::Service::Init::Redhat
+  )
+end

--- a/resources/service_systemd.rb
+++ b/resources/service_systemd.rb
@@ -29,6 +29,7 @@ action :start do
   create_init
 
   service "tomcat_#{new_resource.instance_name}" do
+    provider Chef::Provider::Service::Systemd
     supports restart: true, status: true
     action :start
   end
@@ -36,6 +37,7 @@ end
 
 action :stop do
   service "tomcat_#{new_resource.instance_name}" do
+    provider Chef::Provider::Service::Systemd
     supports status: true
     action :stop
     only_if { ::File.exist?("/etc/systemd/system/tomcat_#{new_resource.instance_name}.service") }
@@ -43,12 +45,16 @@ action :stop do
 end
 
 action :restart do
-  action_stop
-  action_start
+  service "tomcat_#{new_resource.instance_name}" do
+    provider Chef::Provider::Service::Systemd
+    supports status: true
+    action :restart
+  end
 end
 
 action :disable do
   service "tomcat_#{new_resource.instance_name}" do
+    provider Chef::Provider::Service::Systemd
     supports status: true
     action :disable
     only_if { ::File.exist?("/etc/systemd/system/tomcat_#{new_resource.instance_name}.service") }
@@ -59,6 +65,7 @@ action :enable do
   create_init
 
   service "tomcat_#{new_resource.instance_name}" do
+    provider Chef::Provider::Service::Systemd
     supports status: true
     action :enable
     only_if { ::File.exist?("/etc/systemd/system/tomcat_#{new_resource.instance_name}.service") }
@@ -82,6 +89,7 @@ action_class.class_eval do
       group 'root'
       mode '0644'
       notifies :run, 'execute[Load systemd unit file]', :immediately
+      notifies :restart, "service[tomcat_#{new_resource.instance_name}]"
     end
 
     execute 'Load systemd unit file' do

--- a/resources/service_sysv_init.rb
+++ b/resources/service_sysv_init.rb
@@ -103,7 +103,8 @@ action_class.class_eval do
       cookbook 'tomcat'
       variables(
         lock_dir: platform_lock_dir,
-        install_path: derived_install_path
+        install_path: derived_install_path,
+        instance_name: new_resource.instance_name
       )
     end
   end

--- a/resources/service_sysv_init.rb
+++ b/resources/service_sysv_init.rb
@@ -78,7 +78,7 @@ action_class.class_eval do
     )
 
     # the init script will not run without redhat-lsb packages
-    if platform_family?('rhel')
+    if platform_family?('rhel','fedora')
       if node['platform_version'].to_i < 6.0
         package 'redhat-lsb'
       else

--- a/resources/service_sysv_init.rb
+++ b/resources/service_sysv_init.rb
@@ -22,6 +22,7 @@ action :start do
   create_init
 
   service "tomcat_#{new_resource.instance_name}" do
+    provider platform_sysv_init_class
     supports restart: true, status: true
     action :start
   end
@@ -29,6 +30,7 @@ end
 
 action :stop do
   service "tomcat_#{new_resource.instance_name}" do
+    provider platform_sysv_init_class
     supports status: true
     action :stop
     only_if { ::File.exist?("/etc/init.d/tomcat_#{new_resource.instance_name}") }
@@ -36,14 +38,18 @@ action :stop do
 end
 
 action :restart do
-  action_stop
-  action_start
+  service "tomcat_#{new_resource.instance_name}" do
+    provider platform_sysv_init_class
+    supports status: true
+    action :restart
+  end
 end
 
 action :enable do
   create_init
 
   service "tomcat_#{instance_name}" do
+    provider platform_sysv_init_class
     supports status: true
     action :enable
     only_if { ::File.exist?("/etc/init.d/tomcat_#{new_resource.instance_name}") }
@@ -52,6 +58,7 @@ end
 
 action :disable do
   service "tomcat_#{new_resource.instance_name}" do
+    provider platform_sysv_init_class
     supports status: true
     action :disable
     only_if { ::File.exist?("/etc/init.d/tomcat_#{new_resource.instance_name}") }
@@ -84,6 +91,7 @@ action_class.class_eval do
       mode '0755'
       cookbook 'tomcat'
       sensitive new_resource.sensitive
+      notifies :restart, "service[tomcat_#{new_resource.instance_name}]"
       variables(
         env_vars: new_resource.env_vars
       )

--- a/resources/service_sysv_init.rb
+++ b/resources/service_sysv_init.rb
@@ -78,7 +78,7 @@ action_class.class_eval do
     )
 
     # the init script will not run without redhat-lsb packages
-    if platform_family?('rhel','fedora')
+    if platform_family?('rhel', 'fedora')
       if node['platform_version'].to_i < 6.0
         package 'redhat-lsb'
       else

--- a/resources/service_upstart.rb
+++ b/resources/service_upstart.rb
@@ -16,6 +16,7 @@ action :start do
   create_init
 
   service "tomcat_#{new_resource.instance_name}" do
+    provider Chef::Provider::Service::Upstart
     supports restart: true, status: true
     action :start
   end
@@ -23,6 +24,7 @@ end
 
 action :stop do
   service "tomcat_#{new_resource.instance_name}" do
+    provider Chef::Provider::Service::Upstart
     supports status: true
     action :stop
     only_if { ::File.exist?("/etc/init/tomcat_#{new_resource.instance_name}.conf") }
@@ -30,14 +32,18 @@ action :stop do
 end
 
 action :restart do
-  action_stop
-  action_start
+  service "tomcat_#{new_resource.instance_name}" do
+    provider Chef::Provider::Service::Upstart
+    supports restart: true, status: true
+    action :restart
+  end
 end
 
 action :enable do
   create_init
 
   service "tomcat_#{new_resource.instance_name}" do
+    provider Chef::Provider::Service::Upstart
     supports status: true
     action :enable
     only_if { ::File.exist?("/etc/init/tomcat_#{new_resource.instance_name}.conf") }
@@ -46,6 +52,7 @@ end
 
 action :disable do
   service "tomcat_#{new_resource.instance_name}" do
+    provider Chef::Provider::Service::Upstart
     supports status: true
     action :disable
     only_if { ::File.exist?("/etc/init/tomcat_#{new_resource.instance_name}.conf") }
@@ -59,6 +66,7 @@ action_class.class_eval do
     template "/etc/init/tomcat_#{new_resource.instance_name}.conf" do
       source 'init_upstart.erb'
       sensitive new_resource.sensitive
+      notifies :restart, "service[tomcat_#{new_resource.instance_name}]", :immediately
       variables(
         instance: new_resource.instance_name,
         env_vars: new_resource.env_vars,

--- a/resources/service_upstart.rb
+++ b/resources/service_upstart.rb
@@ -66,7 +66,7 @@ action_class.class_eval do
     template "/etc/init/tomcat_#{new_resource.instance_name}.conf" do
       source 'init_upstart.erb'
       sensitive new_resource.sensitive
-      notifies :restart, "service[tomcat_#{new_resource.instance_name}]", :immediately
+      notifies :restart, "service[tomcat_#{new_resource.instance_name}]"
       variables(
         instance: new_resource.instance_name,
         env_vars: new_resource.env_vars,

--- a/templates/init_sysv.erb
+++ b/templates/init_sysv.erb
@@ -67,7 +67,7 @@ RETVAL="0"
 . ${INSTALL_PATH}/bin/setenv.sh
 
 # allow setting SHUTDOWN_WAIT to be set via the setenv file, but use 10s if not
-if [ ! -z  $SHUTDOWN_WAIT ]; then
+if [ -z  "$SHUTDOWN_WAIT" ]; then
   SHUTDOWN_WAIT=10
 fi
 

--- a/templates/init_sysv.erb
+++ b/templates/init_sysv.erb
@@ -5,7 +5,7 @@
 # chkconfig: - 80 20
 #
 ### BEGIN INIT INFO
-# Provides: tomcat
+# Provides: tomcat_<%= @instance_name %>
 # Required-Start: $network $syslog
 # Required-Stop: $network $syslog
 # Default-Start:       2 3 4 5
@@ -32,7 +32,7 @@ fi
 DISTRIB_ID=`lsb_release -i -s 2>/dev/null`
 
 NAME="$(basename $0)"
-INSTALL_PATH="<%= @install_path -%>"
+INSTALL_PATH="<%= @install_path %>"
 LOCK_DIR="<%= @lock_dir %>"
 
 unset ISBOOT

--- a/test/cookbooks/test/recipes/docs_example.rb
+++ b/test/cookbooks/test/recipes/docs_example.rb
@@ -9,8 +9,8 @@ tomcat_install 'docs' do
   install_path '/opt/special/tomcat_docs_7_0_42/'
 end
 
-# start the tomcat docs install
-tomcat_service 'docs' do
+# start the tomcat docs install as a sys-v init service (because we hate ourselves)
+tomcat_service_sysvinit 'docs' do
   action [:start, :enable]
   install_path '/opt/special/tomcat_docs_7_0_42/'
 end


### PR DESCRIPTION
You can use the tomcat_service_WHATEVER names currently, but we're not restarting with env vals change and we can't because we don't specify the init system to use within the provider. Basically the whole thing is currently broken. This isn't a complete fix since the sys-v script is a bit busted right now.