### PR TITLE
Set tomcat_group in service_sysv_init.rb, for issue 275

### DIFF
--- a/resources/service_sysv_init.rb
+++ b/resources/service_sysv_init.rb
@@ -14,7 +14,7 @@ end
 property :instance_name, String, name_property: true
 property :install_path, String
 property :tomcat_user, String, default: lazy { |r| "tomcat_#{r.instance_name}" }
-property :tomcat_group, String, default: nil # this is not used, but allows us swap providers without blowing up
+property :tomcat_group, String, default: lazy { |r| "tomcat_#{r.instance_name}" }
 property :env_vars, Array, default: [
   { 'CATALINA_PID' => '$CATALINA_BASE/bin/tomcat.pid' }
 ]


### PR DESCRIPTION
### Description
Sets TOMCAT_GROUP in /etc/init.d/tomcat_[instance] for SysV init scripts

### Issues Resolved
275

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
