### PR TITLE
fix for issue #277 to support file scheme

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -37,20 +37,25 @@ action_class do
     end
   end
 
+  # create a uri object based on properties and specified file or http scheme
+  def create_uri
+    if new_resource.tarball_uri.nil?
+      unless new_resource.tarball_base_path.start_with?('file')
+        URI.join(new_resource.checksum_base_path, "tomcat-#{major_version}/v#{new_resource.version}/bin/apache-tomcat-#{new_resource.version}.tar.gz.md5")
+      else
+        URI.join(new_resource.checksum_base_path, "apache-tomcat-#{new_resource.version}.tar.gz.md5")
+      end
+    else
+      URI("#{new_resource.tarball_uri}.md5")
+    end
+  end
+
   # fetch the md5 checksum from the mirrors
   # we have to do this since the md5 chef expects isn't hosted
   def fetch_checksum
     # preserve the legacy name of sha1_base_path
     new_resource.checksum_base_path = new_resource.sha1_base_path if new_resource.sha1_base_path
-    uri = if new_resource.tarball_uri.nil?
-            unless new_resource.tarball_base_path.start_with?('file')
-              URI.join(new_resource.checksum_base_path, "tomcat-#{major_version}/v#{new_resource.version}/bin/apache-tomcat-#{new_resource.version}.tar.gz.md5")
-            else
-              URI.join(new_resource.checksum_base_path, "apache-tomcat-#{new_resource.version}.tar.gz.md5")
-            end
-          else
-            URI("#{new_resource.tarball_uri}.md5")
-          end
+    uri = create_uri()
     if uri.scheme == 'file'
       open(uri.path).read.split(' ')[0]
     else


### PR DESCRIPTION
### Description
This fix enables use of file:/// for example given the following recipe below tomcat_install will work with file:///tmp/ to install tomcat from /tmp.

```
%w(apache-tomcat-8.0.36.tar.gz apache-tomcat-8.0.36.tar.gz.md5).each do |f|
  cookbook_file "/tmp/#{f}" do 
    source f                   
    owner 'root'
    group 'root'
    mode '0644'
  end
end 

tomcat_install 'helloworld' do 
  tarball_base_path 'file:///tmp/'
  checksum_base_path 'file:///tmp/'
  tomcat_user 'cool_user'      
  tomcat_group 'cool_group'    
end
```

### Issues Resolved

This is designed to fix issue #277 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
