### PR TITLE
More reliably set the service type

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,7 +13,6 @@ platforms:
   - name: debian-7.11
   - name: debian-8.6
   - name: fedora-25
-    run_list: yum::dnf_yum_compat
   - name: opensuse-leap-42.1
   - name: ubuntu-14.04
   - name: ubuntu-16.04

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -31,10 +31,9 @@ action_class do
 
   # ensure the version is X.Y.Z format
   def validate_version
-    unless new_resource.version =~ /\d+.\d+.\d+/
-      Chef::Log.fatal("The version must be in X.Y.Z format. Passed value: #{new_resource.version}")
-      raise
-    end
+    return if new_resource.version =~ /\d+.\d+.\d+/
+    Chef::Log.fatal("The version must be in X.Y.Z format. Passed value: #{new_resource.version}")
+    raise
   end
 
   # fetch the md5 checksum from the mirrors

--- a/resources/service_systemd.rb
+++ b/resources/service_systemd.rb
@@ -2,20 +2,8 @@ provides :tomcat_service_systemd
 
 provides :tomcat_service, platform: 'fedora'
 
-provides :tomcat_service, platform: %w(redhat centos scientific oracle) do |node| # ~FC005
-  node['platform_version'].to_f >= 7.0
-end
-
-provides :tomcat_service, platform: 'debian' do |node|
-  node['platform_version'].to_i >= 8
-end
-
-provides :tomcat_service, platform_family: 'suse' do |node|
-  node['platform_version'].to_f >= 13.0
-end
-
-provides :tomcat_service, platform: 'ubuntu' do |node|
-  node['platform_version'].to_f >= 15.10
+provides :tomcat_service, os: 'linux' do |_node|
+  Chef::Platform::ServiceHelpers.service_resource_providers.include?(:systemd)
 end
 
 property :instance_name, String, name_property: true

--- a/resources/service_systemd.rb
+++ b/resources/service_systemd.rb
@@ -11,7 +11,7 @@ property :install_path, String
 property :tomcat_user, String, default: lazy { |r| "tomcat_#{r.instance_name}" }
 property :tomcat_group, String, default: lazy { |r| "tomcat_#{r.instance_name}" }
 property :env_vars, Array, default: [
-  { 'CATALINA_PID' => '$CATALINA_BASE/bin/tomcat.pid' }
+  { 'CATALINA_PID' => '$CATALINA_BASE/bin/tomcat.pid' },
 ]
 property :sensitive, [true, false], default: false
 

--- a/resources/service_sysv_init.rb
+++ b/resources/service_sysv_init.rb
@@ -6,7 +6,7 @@ property :install_path, String
 property :tomcat_user, String, default: lazy { |r| "tomcat_#{r.instance_name}" }
 property :tomcat_group, String, default: lazy { |r| "tomcat_#{r.instance_name}" }
 property :env_vars, Array, default: [
-  { 'CATALINA_PID' => '$CATALINA_BASE/bin/tomcat.pid' }
+  { 'CATALINA_PID' => '$CATALINA_BASE/bin/tomcat.pid' },
 ]
 property :sensitive, kind_of: [TrueClass, FalseClass], default: false
 

--- a/resources/service_sysv_init.rb
+++ b/resources/service_sysv_init.rb
@@ -1,15 +1,5 @@
 provides :tomcat_service_sysvinit
-
-provides :tomcat_service, platform_family: 'suse'
-provides :tomcat_service, platform: 'amazon'
-
-provides :tomcat_service, platform: %w(redhat centos scientific oracle) do |node| # ~FC005
-  node['platform_version'].to_f < 7.0
-end
-
-provides :tomcat_service, platform: 'debian' do |node|
-  node['platform_version'].to_i < 8
-end
+provides :tomcat_service, os: 'linux'
 
 property :instance_name, String, name_property: true
 property :install_path, String

--- a/resources/service_upstart.rb
+++ b/resources/service_upstart.rb
@@ -11,7 +11,7 @@ property :install_path, String
 property :tomcat_user, String, default: lazy { |r| "tomcat_#{r.instance_name}" }
 property :tomcat_group, String, default: lazy { |r| "tomcat_#{r.instance_name}" }
 property :env_vars, Array, default: [
-  { 'CATALINA_PID' => '$CATALINA_BASE/bin/tomcat.pid' }
+  { 'CATALINA_PID' => '$CATALINA_BASE/bin/tomcat.pid' },
 ]
 property :sensitive, kind_of: [TrueClass, FalseClass], default: false
 

--- a/resources/service_upstart.rb
+++ b/resources/service_upstart.rb
@@ -1,8 +1,9 @@
 
 provides :tomcat_service_upstart
 
-provides :tomcat_service, platform: 'ubuntu' do |node|
-  node['platform_version'].to_f < 15.10
+provides :tomcat_service, platform_family: 'debian' do |_node|
+  Chef::Platform::ServiceHelpers.service_resource_providers.include?(:upstart) &&
+    !Chef::Platform::ServiceHelpers.service_resource_providers.include?(:systemd)
 end
 
 property :instance_name, String, name_property: true


### PR DESCRIPTION
Don't rely on knowing the appropriate service types for each distro. Let chef detect the underlying capabilities