### PR TITLE
Avoid deprecation warnings / failures in Chef 13

### DIFF
--- a/.delivery/project.toml
+++ b/.delivery/project.toml
@@ -1,0 +1,1 @@
+remote_file = "https://raw.githubusercontent.com/chef-cookbooks/community_cookbook_tools/master/delivery/project.toml"

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -1,3 +1,22 @@
+#
+# Cookbook:: tomcat
+# Resource:: install
+#
+# Copyright:: 2016-2017, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 property :instance_name, String, name_property: true
 property :version, String, default: '8.0.36'
 property :install_path, String, default: lazy { |r| "/opt/tomcat_#{r.instance_name}_#{r.version.tr('.', '_')}/" }

--- a/resources/service_systemd.rb
+++ b/resources/service_systemd.rb
@@ -1,6 +1,5 @@
 provides :tomcat_service_systemd
 
-provides :tomcat_service, platform: 'fedora'
 
 provides :tomcat_service, os: 'linux' do |_node|
   Chef::Platform::ServiceHelpers.service_resource_providers.include?(:systemd)

--- a/resources/service_systemd.rb
+++ b/resources/service_systemd.rb
@@ -1,5 +1,23 @@
-provides :tomcat_service_systemd
+#
+# Cookbook:: tomcat
+# Resource:: service_systemd
+#
+# Copyright:: 2016-2017, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
+provides :tomcat_service_systemd
 
 provides :tomcat_service, os: 'linux' do |_node|
   Chef::Platform::ServiceHelpers.service_resource_providers.include?(:systemd)

--- a/resources/service_sysv_init.rb
+++ b/resources/service_sysv_init.rb
@@ -8,7 +8,6 @@ property :tomcat_group, String, default: lazy { |r| "tomcat_#{r.instance_name}" 
 property :env_vars, Array, default: [
   { 'CATALINA_PID' => '$CATALINA_BASE/bin/tomcat.pid' },
 ]
-property :sensitive, kind_of: [TrueClass, FalseClass], default: false
 
 action :start do
   create_init

--- a/resources/service_sysv_init.rb
+++ b/resources/service_sysv_init.rb
@@ -1,3 +1,22 @@
+#
+# Cookbook:: tomcat
+# Resource:: service_sysvinit
+#
+# Copyright:: 2016-2017, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 provides :tomcat_service_sysvinit
 provides :tomcat_service, os: 'linux'
 

--- a/resources/service_upstart.rb
+++ b/resources/service_upstart.rb
@@ -13,7 +13,6 @@ property :tomcat_group, String, default: lazy { |r| "tomcat_#{r.instance_name}" 
 property :env_vars, Array, default: [
   { 'CATALINA_PID' => '$CATALINA_BASE/bin/tomcat.pid' },
 ]
-property :sensitive, kind_of: [TrueClass, FalseClass], default: false
 
 action :start do
   create_init

--- a/resources/service_upstart.rb
+++ b/resources/service_upstart.rb
@@ -1,3 +1,21 @@
+#
+# Cookbook:: tomcat
+# Resource:: service_upstart
+#
+# Copyright:: 2016-2017, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 provides :tomcat_service_upstart
 


### PR DESCRIPTION
Sensitive can be applied to any resource and doesn't need to be defined in the resource.