### PR TITLE
Fix HTTPS checksums and add tarball_validate_ssl param

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ tomcat_install installs an instance of the tomcat binary direct from Apache's mi
 - `tarball_base_path`: The base path to the apache mirror containing the tarballs. Default: '<http://archive.apache.org/dist/tomcat/>'
 - `checksum_base_path`: The base path to the apache mirror containing the md5 file. Default: '<http://archive.apache.org/dist/tomcat/>'
 - `tarball_uri`: The complete path to the tarball. If specified would override (`tarball_base_path` and `checksum_base_path`). checksum will be loaded from "#{tarball_uri}.md5". This attribute is useful, if you are hosting tomcat tarballs from artifact repositories such as nexus.
+- `tarball_validate_ssl`: Validate the SSL certificate, if `tarball_uri` is using HTTPS. Default true.
 - `exclude_docs`: Exclude ./webapps/docs from installation. Default true.
 - `exclude_examples`: Exclude ./webapps/examples from installation. Default true.
 - `exclude_manager`: Exclude ./webapps/manager from installation. Default: false.

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -28,6 +28,7 @@ property :exclude_examples, [true, false], default: true
 property :exclude_manager, [true, false], default: false
 property :exclude_hostmanager, [true, false], default: false
 property :tarball_uri, String
+property :tarball_validate_ssl, [true, false], default: true
 property :tomcat_user, String, default: lazy { |r| "tomcat_#{r.instance_name}" }
 property :tomcat_group, String, default: lazy { |r| "tomcat_#{r.instance_name}" }
 
@@ -66,12 +67,11 @@ action_class do
             URI("#{new_resource.tarball_uri}.md5")
           end
     request = Net::HTTP.new(uri.host, uri.port)
-    response = request.get(uri)
     if uri.to_s.start_with?('https')
       request.use_ssl = true
-      request.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      request.verify_mode = OpenSSL::SSL::VERIFY_NONE unless new_resource.tarball_validate_ssl
     end
-
+    response = request.get(uri)
     if response.code != '200'
       Chef::Log.fatal("Fetching the Tomcat tarball checksum at #{uri} resulted in an error #{response.code}")
       raise


### PR DESCRIPTION
Signed-off-by: Alex Lindeman <alindeman@gannett.com>

### Description

`request.use_ssl` was not being set until after `request.get` was being called, preventing `use_ssl` from taking effect. This fixes fetching checksums from HTTPS tarball URLs.

This also adds a `tarball_validate_ssl` parameter to the `tomcat_install` provider, which makes skipping SSL verification optional (instead of always skipping it). By default SSL verification will _not_ be skipped.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
