### PR TITLE
Cleanly start and stop tomcat instance using systemd.

### DIFF
--- a/templates/init_systemd.erb
+++ b/templates/init_systemd.erb
@@ -5,7 +5,7 @@ Description=<%= @instance %> Apache Tomcat Application
 After=syslog.target network.target
 
 [Service]
-Type=simple
+Type=forking
 
 <% @env_vars.each do |h| -%>
   <% h.each_pair do |k,v| -%>
@@ -13,8 +13,9 @@ Environment="<%= k -%>=<%= v %>"
   <% end -%>
 <% end -%>
 
-ExecStart=<%= @install_path %>/bin/catalina.sh run
+ExecStart=<%= @install_path %>/bin/catalina.sh start
 ExecStop=<%= @install_path %>/bin/catalina.sh stop
+SuccessExitStatus=0 143
 Restart=on-failure
 RestartSec=2
 


### PR DESCRIPTION
Signed-off-by: Nathan Cerny <ncerny@gmail.com>

### Description

This PR resolves issues with starting and stopping catalina server instances from systemd.
Exit 143 happens when java receives a kill signal from the OS, which catalina sends when a stop command is received before the service is completely up.

### Issues Resolved

#288 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
