### PR TITLE
Add ability to set the tomcat user's shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ tomcat_install installs an instance of the tomcat binary direct from Apache's mi
 - `exclude_examples`: Exclude ./webapps/examples from installation. Default `true`.
 - `exclude_manager`: Exclude ./webapps/manager from installation. Default: `false`.
 - `exclude_hostmanager`: Exclude ./webapps/host-manager from installation. Default: `false`.
+- `tomcat_user`: User to run tomcat as. Default: `tomcat_INSTANCENAME`
+- `tomcat_group`: Group of the tomcat user. Default: `tomcat_INSTANCENAME`
+- `tomcat_user_shell`: Shell of the tomcat user. Default: `/bin/false`
 
 #### example
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -33,6 +33,7 @@ property :tarball_path, String, default: lazy { |r| "#{Chef::Config['file_cache_
 property :tarball_validate_ssl, [true, false], default: true
 property :tomcat_user, String, default: lazy { |r| "tomcat_#{r.instance_name}" }
 property :tomcat_group, String, default: lazy { |r| "tomcat_#{r.instance_name}" }
+property :tomcat_user_shell, String, default: '/bin/false'
 
 action :install do
   validate_version
@@ -50,7 +51,7 @@ action :install do
 
   user new_resource.tomcat_user do
     gid new_resource.tomcat_group
-    shell '/bin/false'
+    shell new_resource.tomcat_user_shell
     system true
     action :create
   end

--- a/test/integration/multi_instance/default_spec.rb
+++ b/test/integration/multi_instance/default_spec.rb
@@ -57,7 +57,7 @@ end
 %w(cool_user tomcat_docs).each do |user_name|
   describe user(user_name) do
     it { should exist }
-    its('shell') should eq '/bin/false'
+    its('shell') { should eq '/bin/false' }
   end
 end
 

--- a/test/integration/multi_instance/default_spec.rb
+++ b/test/integration/multi_instance/default_spec.rb
@@ -57,6 +57,7 @@ end
 %w(cool_user tomcat_docs).each do |user_name|
   describe user(user_name) do
     it { should exist }
+    its('shell') should eq '/bin/false'
   end
 end
 

--- a/test/integration/multi_instance/default_spec.rb
+++ b/test/integration/multi_instance/default_spec.rb
@@ -9,9 +9,11 @@ describe file('/opt/tomcat_helloworld_8_0_43') do
 end
 
 # make sure we get our override env value and not both
-describe file('/etc/init/tomcat_helloworld.conf') do
-  its('content') { should match(%r{env CATALINA_BASE="/opt/tomcat_helloworld/"}) }
-  its('content') { should_not match(%r{env CATALINA_BASE="/opt/tomcat_helloworld"}) }
+if file('/etc/init/tomcat_helloworld.conf').exist?
+  describe file('/etc/init/tomcat_helloworld.conf') do
+    its('content') { should match(%r{env CATALINA_BASE="/opt/tomcat_helloworld/"}) }
+    its('content') { should_not match(%r{env CATALINA_BASE="/opt/tomcat_helloworld"}) }
+  end
 end
 
 describe file('/opt/tomcat_dirworld_8_0_43') do


### PR DESCRIPTION
Fixes #313

Signed-off-by: Eric Heydrick <eheydrick@gmail.com>

### Description

This allows setting the tomcat user's shell to something other than `/bin/false`.
Also fixes tests that were failing on non-upstart platforms (i.e. everything not Ubuntu 14.04).

### Issues Resolved

#313

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
