### PR TITLE
allow setting custom properties for systemd services, for instance to…

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache-2.0'
 description      'Installs Apache Tomcat and manages the service'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.0.0'
+version          '3.0.1'
 
 %w(ubuntu debian redhat centos suse opensuse opensuseleap scientific oracle amazon zlinux).each do |os|
   supports os

--- a/resources/service_systemd.rb
+++ b/resources/service_systemd.rb
@@ -30,6 +30,7 @@ property :tomcat_group, String, default: lazy { |r| "tomcat_#{r.instance_name}" 
 property :env_vars, Array, default: [
   { 'CATALINA_PID' => '$CATALINA_BASE/bin/tomcat.pid' },
 ]
+property :service_vars, Array, default: []
 
 action :start do
   create_init
@@ -89,6 +90,7 @@ action_class do
       variables(
         instance: new_resource.instance_name,
         env_vars: envs_with_catalina_base,
+        service_vars: new_resource.service_vars,
         install_path: derived_install_path,
         user: new_resource.tomcat_user,
         group: new_resource.tomcat_group

--- a/templates/init_systemd.erb
+++ b/templates/init_systemd.erb
@@ -13,6 +13,12 @@ Environment="<%= k -%>=<%= v %>"
   <% end -%>
 <% end -%>
 
+<% @service_vars.each do |h| -%>
+  <% h.each_pair do |k,v| -%>
+<%= k -%>=<%= v %>
+  <% end -%>
+<% end -%>
+
 ExecStart=<%= @install_path %>/bin/catalina.sh start
 ExecStop=<%= @install_path %>/bin/catalina.sh stop
 SuccessExitStatus=0 143


### PR DESCRIPTION
Signed-off-by: Bas <bas.steen@nl.pwc.com>

### Description

[Describe what this change achieves]
This change allow users to add custom properties to a systemd service. For instance properties that allow setting open file descriptors with LimitNOFILE

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ v ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
