### PR TITLE
Make checksum algorithm configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ tomcat_install installs an instance of the tomcat binary direct from Apache's mi
 - `version`: The version to install. Default: 8.0.47
 - `install_path`: Full path to the install directory. Default: /opt/tomcat_INSTANCENAME_VERSION
 - `tarball_base_uri`: The base uri to the apache mirror containing the tarballs. Default: '<http://archive.apache.org/dist/tomcat/>'
-- `checksum_base_uri`: The base uri to the apache mirror containing the md5 file. Default: '<http://archive.apache.org/dist/tomcat/>'
+- `checksum_base_uri`: The base uri to the apache mirror containing the checksum file. Default: '<http://archive.apache.org/dist/tomcat/>'
+- `checksum_type`: The type of checksum to apply (e.g. sha256, sha1, md5). Default: '' (try all)
 - `verify_checksum`: Whether the checksum should be verified against `checksum_base_uri`. Default: `true`.
 - `dir_mode`: Directory permissions of the `install_path`. Default: `'0750'`.
-- `tarball_uri`: The complete uri to the tarball. If specified would override (`tarball_base_uri` and `checksum_base_uri`). checksum will be loaded from "#{tarball_uri}.md5". This attribute is useful, if you are hosting tomcat tarballs from artifact repositories such as nexus.
+- `tarball_uri`: The complete uri to the tarball. If specified would override (`tarball_base_uri` and `checksum_base_uri`). checksum will be loaded from "#{tarball_uri}.#{checksum_type}". This attribute is useful, if you are hosting tomcat tarballs from artifact repositories such as nexus.
 - `tarball_path`: Local path on disk to the tarball. If the file does not exist, or the checksum does not match, it will be downloaded from `tarball_uri`.
 - `tarball_validate_ssl`: Validate the SSL certificate, if `tarball_uri` is using HTTPS. Default `true`.
 - `exclude_docs`: Exclude ./webapps/docs from installation. Default `true`.


### PR DESCRIPTION
Apache are phasing out md5 checksums, so make hash algorithm configurable

Signed-off-by: Neil Duff-Howie <neil.howie@yahoo.co.uk>

### Description

When fetching the hash, it tries the available types by default, but also adds a new attribute 'checksum_type', which allows overriding to a specific hash algorthithm

### Issues Resolved

#323 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
