### PR TITLE
 Verify using sha512 checksums for later version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the tomcat cookbook.
 
+## 3.2.0 (2018-09-26)
+
+- Verify with sha512 sums for versions ~> 7.0.84, 8.0.48, 8.5.24, 9.0.10
+
 ## 3.1.0 (2018-08-07)
 
 - Allow setting custom properties for systemd services, for instance to set open file descriptors with LimitNOFILE

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ tomcat_install installs an instance of the tomcat binary direct from Apache's mi
 - `version`: The version to install. Default: 8.0.47
 - `install_path`: Full path to the install directory. Default: /opt/tomcat_INSTANCENAME_VERSION
 - `tarball_base_uri`: The base uri to the apache mirror containing the tarballs. Default: '<http://archive.apache.org/dist/tomcat/>'
-- `checksum_base_uri`: The base uri to the apache mirror containing the md5 file. Default: '<http://archive.apache.org/dist/tomcat/>'
+- `checksum_base_uri`: The base uri to the apache mirror containing the md5 or sha512 file. Default: '<http://archive.apache.org/dist/tomcat/>'
 - `verify_checksum`: Whether the checksum should be verified against `checksum_base_uri`. Default: `true`.
 - `dir_mode`: Directory permissions of the `install_path`. Default: `'0750'`.
-- `tarball_uri`: The complete uri to the tarball. If specified would override (`tarball_base_uri` and `checksum_base_uri`). checksum will be loaded from "#{tarball_uri}.md5". This attribute is useful, if you are hosting tomcat tarballs from artifact repositories such as nexus.
+- `tarball_uri`: The complete uri to the tarball. If specified would override (`tarball_base_uri` and `checksum_base_uri`). checksum will be loaded from "#{tarball_uri}.{md5,sha512}". This attribute is useful, if you are hosting tomcat tarballs from artifact repositories such as nexus. `sha512` sums are used for version constraints: `~> 7.0.84`, `~> 8.0.48`, `~> 8.5.24`, `~> 9.0.10`.
 - `tarball_path`: Local path on disk to the tarball. If the file does not exist, or the checksum does not match, it will be downloaded from `tarball_uri`.
 - `tarball_validate_ssl`: Validate the SSL certificate, if `tarball_uri` is using HTTPS. Default `true`.
 - `exclude_docs`: Exclude ./webapps/docs from installation. Default `true`.

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -23,3 +23,7 @@ suites:
 - name: multi_instance
   run_list:
   - recipe[test]
+
+- name: checksum_examples
+  run_list:
+  - recipe[test::sum_examples]

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache-2.0'
 description      'Installs Apache Tomcat and manages the service'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.1.0'
+version          '3.2.0'
 
 %w(ubuntu debian redhat centos suse opensuse opensuseleap scientific oracle amazon zlinux).each do |os|
   supports os

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -117,18 +117,18 @@ action_class do
 
   # returns the URI of the apache.org generated checksum based on either
   # an absolute path to the tarball or the tarball based path.
-  def checksum_uri
+  def checksum_uri(sum_form)
     if new_resource.tarball_uri.empty?
-      URI.join(new_resource.checksum_base_uri, "tomcat-#{major_version}/v#{new_resource.version}/bin/apache-tomcat-#{new_resource.version}.tar.gz.md5")
+      URI.join(new_resource.checksum_base_uri, "tomcat-#{major_version}/v#{new_resource.version}/bin/apache-tomcat-#{new_resource.version}.tar.gz.#{sum_form}")
     else
-      URI("#{new_resource.tarball_uri}.md5")
+      URI("#{new_resource.tarball_uri}.#{sum_form}")
     end
   end
 
   # fetch the md5 checksum from the mirrors
   # we have to do this since the md5 chef expects isn't hosted
-  def fetch_checksum
-    uri = checksum_uri
+  def fetch_checksum(form)
+    uri = checksum_uri(form)
     request = Net::HTTP.new(uri.host, uri.port)
     if uri.to_s.start_with?('https')
       request.use_ssl = true
@@ -148,8 +148,24 @@ action_class do
   # validate the mirror checksum against the on disk checksum
   # return true if they match. Append .bad to the cached copy to prevent using it next time
   def validate_checksum(file_to_check)
-    desired = fetch_checksum
-    actual = Digest::MD5.hexdigest(::File.read(file_to_check))
+    # Apache started using sha512 (replacing md5) in these versions and now
+    # only publishes sha512 checksums
+    sum_form = case Gem::Version.new(new_resource.version)
+               when -> (v) { Gem::Requirement.new('~> 7.0.84').satisfied_by?(v) }
+                 'sha512'
+               when -> (v) { Gem::Requirement.new('~> 8.0.48').satisfied_by?(v) }
+                 'sha512'
+               when -> (v) { Gem::Requirement.new('~> 8.5.24').satisfied_by?(v) }
+                 'sha512'
+               when -> (v) { Gem::Requirement.new('~> 9.0.10').satisfied_by?(v) }
+                 'sha512'
+               else
+                 'md5'
+               end
+
+    desired = fetch_checksum(sum_form)
+    klass = Object.const_get("Digest::#{sum_form.upcase}")
+    actual = klass.hexdigest(::File.read(file_to_check))
 
     if desired == actual
       true

--- a/test/cookbooks/test/recipes/sum_examples.rb
+++ b/test/cookbooks/test/recipes/sum_examples.rb
@@ -1,0 +1,20 @@
+# make sure we have java installed
+include_recipe 'java'
+
+# Install Tomcat 9.0.10 (and verify against sha512 sums since we're 9.0.10 or later)
+tomcat_install 'docs_90' do
+  version '9.0.10'
+  exclude_examples false
+  exclude_docs false
+  verify_checksum true
+  install_path '/opt/special/tomcat_docs_9_0_10/'
+end
+
+# Install Tomcat 8.5.23 (and verify against md5 sums since we're earlier than 8.5.24)
+tomcat_install 'docs_85' do
+  version '8.5.23'
+  exclude_examples false
+  exclude_docs false
+  verify_checksum true
+  install_path '/opt/special/tomcat_docs_8_5_23/'
+end


### PR DESCRIPTION
### Description

...of tomcat

### Issues Resolved

Just mine seems like 🙄

### Check List
- [x] All tests pass.

```
$ chef exec delivery local all
Chef Delivery
Running Every Stage
Running Lint Phase
Inspecting 18 files
..................

18 files inspected, no offenses detected
Running Syntax Phase
Checking 11 files
...........

Running Unit Phase

default recipe on ubuntu 16.04
  converges successfully

Finished in 0.42786 seconds (files took 2.78 seconds to load)
1 example, 0 failures

Running Provision Phase
skipping
Running Deploy Phase
skipping
Running Smoke Phase
skipping
Running Functional Phase
skipping
Running Cleanup Phase
skipping
```

- [ ] New functionality includes testing.
I started down the road of extending/writing chefspec tests for `tomcat_install#validate_checksum` but it seems like writing tests for methods that are in custom resources (which aren't structured as `libraries`) is painful if not impossible. So instead, I added a `sum_examples` and a `.kitchen.yml` suite to run it with.

- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
