### PR TITLE
[ISSUE-337] Make user and group creation optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ tomcat_install installs an instance of the tomcat binary direct from Apache's mi
 - `tomcat_user`: User to run tomcat as. Default: `tomcat_INSTANCENAME`
 - `tomcat_group`: Group of the tomcat user. Default: `tomcat_INSTANCENAME`
 - `tomcat_user_shell`: Shell of the tomcat user. Default: `/bin/false`
+- `create_user`: Creates the specified tomcat_user within the OS.  Default `true`.
+- `create_group`: Creates the specified tomcat_group within the OS. Default `true`.
 
 #### example
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -34,6 +34,8 @@ property :tarball_validate_ssl, [true, false], default: true, desired_state: fal
 property :tomcat_user, String, default: lazy { |r| "tomcat_#{r.instance_name}" }
 property :tomcat_group, String, default: lazy { |r| "tomcat_#{r.instance_name}" }
 property :tomcat_user_shell, String, default: '/bin/false'
+property :create_user, [true, false], default: true, desired_state: false
+property :create_group, [true, false], default: true, desired_state: false
 
 action :install do
   validate_version
@@ -47,6 +49,7 @@ action :install do
   group new_resource.tomcat_group do
     action :create
     append true
+    only_if { new_resource.create_group }
   end
 
   user new_resource.tomcat_user do
@@ -54,6 +57,7 @@ action :install do
     shell new_resource.tomcat_user_shell
     system true
     action :create
+    only_if { new_resource.create_user }
   end
 
   directory 'tomcat install dir' do


### PR DESCRIPTION
### Description

This change adds two new install boolean properties create_user and create_group which default to true for backwards compatibility.  They allow wrappers to bypass the user and group resources within the install.rb resource file.  This solves a problem when trying to use an LDAP user that already exists on a server but is not in /etc/passwd and cannot be created there by the user resource.  

### Issues Resolved

Issue 337 - Allow LDAP IDs which are not in /etc/passwd

### Check List
Note: some timeouts in kitchen tests were present before code modifications and not related to my changes.  

- [ x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ x] New functionality includes testing.
- [ x] New functionality has been documented in the README if applicable
- [ x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
