### PR TITLE
[333]: add resource props for template/cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ tomcat_install installs an instance of the tomcat binary direct from Apache's mi
 - `tomcat_user_shell`: Shell of the tomcat user. Default: `/bin/false`
 - `create_user`: Creates the specified tomcat_user within the OS.  Default `true`.
 - `create_group`: Creates the specified tomcat_group within the OS. Default `true`.
+- `service_template_source`: Source template file for the sys-v/upstart/systemd service definition. Default: 'init_sysv.erb'
+- `service_template_cookbook`: Cookbook from which to source the sys-v/upstart/systemd service definition template. Default: 'tomcat'
+- `setenv_template_source`: Source template file for the sys-v 'setenv' file. Default: 'setenv.erb'
+- `setenv_template_cookbook`: Cookbook from which to source the sys-v 'setenv' file. Default: 'tomcat'
 
 #### example
 

--- a/resources/service_systemd.rb
+++ b/resources/service_systemd.rb
@@ -32,6 +32,9 @@ property :env_vars, Array, default: [
 ]
 property :service_vars, Array, default: []
 
+property :service_template_source, String, default: 'init_systemd.erb'
+property :service_template_cookbook, String, default: 'tomcat'
+
 action :start do
   create_init
 
@@ -85,7 +88,7 @@ action_class do
 
   def create_init
     template "/etc/systemd/system/tomcat_#{new_resource.instance_name}.service" do
-      source 'init_systemd.erb'
+      source new_resource.service_template_source
       sensitive new_resource.sensitive
       variables(
         instance: new_resource.instance_name,
@@ -95,7 +98,7 @@ action_class do
         user: new_resource.tomcat_user,
         group: new_resource.tomcat_group
       )
-      cookbook 'tomcat'
+      cookbook new_resource.service_template_cookbook
       owner 'root'
       group 'root'
       mode '0644'

--- a/resources/service_sysv_init.rb
+++ b/resources/service_sysv_init.rb
@@ -28,6 +28,12 @@ property :env_vars, Array, default: [
   { 'CATALINA_PID' => '$CATALINA_BASE/bin/tomcat.pid' },
 ]
 
+property :service_template_source, String, default: 'init_sysv.erb'
+property :service_template_cookbook, String, default: 'tomcat'
+
+property :setenv_template_source, String, default: 'setenv.erb'
+property :setenv_template_cookbook, String, default: 'tomcat'
+
 action :start do
   create_init
 
@@ -99,9 +105,9 @@ action_class do
     end
 
     template "#{derived_install_path}/bin/setenv.sh" do
-      source 'setenv.erb'
+      source new_resource.setenv_template_source
       mode '0755'
-      cookbook 'tomcat'
+      cookbook new_resource.setenv_template_cookbook
       sensitive new_resource.sensitive
       notifies :restart, "service[tomcat_#{new_resource.instance_name}]"
       variables(
@@ -111,8 +117,8 @@ action_class do
 
     template "/etc/init.d/tomcat_#{new_resource.instance_name}" do
       mode '0755'
-      source 'init_sysv.erb'
-      cookbook 'tomcat'
+      source new_resource.service_template_source
+      cookbook new_resource.service_template_cookbook
       variables(
         user: new_resource.tomcat_user,
         group: new_resource.tomcat_group,

--- a/resources/service_upstart.rb
+++ b/resources/service_upstart.rb
@@ -32,6 +32,9 @@ property :env_vars, Array, default: [
   { 'CATALINA_PID' => '$CATALINA_BASE/bin/tomcat.pid' },
 ]
 
+property :service_template_source, String, default: 'init_upstart.erb'
+property :service_template_cookbook, String, default: 'tomcat'
+
 action :start do
   create_init
 
@@ -84,7 +87,7 @@ action_class do
 
   def create_init
     template "/etc/init/tomcat_#{new_resource.instance_name}.conf" do
-      source 'init_upstart.erb'
+      source new_resource.service_template_source
       sensitive new_resource.sensitive
       notifies :restart, "service[tomcat_#{new_resource.instance_name}]"
       variables(
@@ -94,7 +97,7 @@ action_class do
         env_vars: envs_with_catalina_base,
         install_path: derived_install_path
       )
-      cookbook 'tomcat'
+      cookbook new_resource.service_template_cookbook
       owner 'root'
       group 'root'
       mode '0644'

--- a/test/cookbooks/test/files/template_server.xml
+++ b/test/cookbooks/test/files/template_server.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="8005" shutdown="SHUTDOWN">
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
+  <!--APR library loader. Documentation at /docs/apr.html -->
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm to authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+
+    <!--The connectors can use a shared executor, you can define one or more named thread pools-->
+    <!--
+    <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
+        maxThreads="150" minSpareThreads="4"/>
+    -->
+
+
+    <!-- A "Connector" represents an endpoint by which requests are received
+         and responses are returned. Documentation at :
+         Java HTTP Connector: /docs/config/http.html
+         Java AJP  Connector: /docs/config/ajp.html
+         APR (HTTP/AJP) Connector: /docs/apr.html
+         Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
+    -->
+    <Connector port="8082" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8445" />
+    <!-- A "Connector" using the shared thread pool-->
+    <!--
+    <Connector executor="tomcatThreadPool"
+               port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
+    -->
+    <!-- Define an SSL/TLS HTTP/1.1 Connector on port 8443
+         This connector uses the NIO implementation. The default
+         SSLImplementation will depend on the presence of the APR/native
+         library and the useOpenSSL attribute of the
+         AprLifecycleListener.
+         Either JSSE or OpenSSL style configuration may be used regardless of
+         the SSLImplementation selected. JSSE style configuration is used below.
+    -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+               maxThreads="150" SSLEnabled="true">
+        <SSLHostConfig>
+            <Certificate certificateKeystoreFile="conf/localhost-rsa.jks"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    -->
+    <!-- Define an SSL/TLS HTTP/1.1 Connector on port 8443 with HTTP/2
+         This connector uses the APR/native implementation which always uses
+         OpenSSL for TLS.
+         Either JSSE or OpenSSL style configuration may be used. OpenSSL style
+         configuration is used below.
+    -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11AprProtocol"
+               maxThreads="150" SSLEnabled="true" >
+        <UpgradeProtocol className="org.apache.coyote.http2.Http2Protocol" />
+        <SSLHostConfig>
+            <Certificate certificateKeyFile="conf/localhost-rsa-key.pem"
+                         certificateFile="conf/localhost-rsa-cert.pem"
+                         certificateChainFile="conf/localhost-rsa-chain.pem"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    -->
+
+    <!-- Define an AJP 1.3 Connector on port 8009 -->
+    <!--
+    <Connector protocol="AJP/1.3"
+               address="::1"
+               port="8009"
+               redirectPort="8443" />
+    -->
+
+    <!-- An Engine represents the entry point (within Catalina) that processes
+         every request.  The Engine implementation for Tomcat stand alone
+         analyzes the HTTP headers included with the request, and passes them
+         on to the appropriate Host (virtual host).
+         Documentation at /docs/config/engine.html -->
+
+    <!-- You should set jvmRoute to support load-balancing via AJP ie :
+    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+    -->
+    <Engine name="Catalina" defaultHost="localhost">
+
+      <!--For clustering, please take a look at documentation at:
+          /docs/cluster-howto.html  (simple how to)
+          /docs/config/cluster.html (reference documentation) -->
+      <!--
+      <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
+      -->
+
+      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host name="localhost"  appBase="webapps"
+            unpackWARs="true" autoDeploy="true">
+
+        <!-- SingleSignOn valve, share authentication between web applications
+             Documentation at: /docs/config/valve.html -->
+        <!--
+        <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
+        -->
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent to using pattern="common" -->
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log" suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+
+      </Host>
+    </Engine>
+  </Service>
+</Server>

--- a/test/cookbooks/test/metadata.rb
+++ b/test/cookbooks/test/metadata.rb
@@ -5,4 +5,6 @@ license 'Apache-2.0'
 version '1.0.0'
 
 depends 'tomcat'
-depends 'java'
+
+# final version to suppose default recipe
+depends 'java', '<= 6.0.0'

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -2,3 +2,4 @@ apt_update 'update'
 
 include_recipe 'test::docs_example'
 include_recipe 'test::helloworld_example'
+include_recipe 'test::template_example'

--- a/test/cookbooks/test/recipes/template_example.rb
+++ b/test/cookbooks/test/recipes/template_example.rb
@@ -1,0 +1,22 @@
+include_recipe 'java'
+
+instance_name = 'template'
+service_name = "tomcat_#{instance_name}"
+
+tomcat_install instance_name do
+  version '9.0.34'
+end
+
+cookbook_file "/opt/#{service_name}/conf/server.xml" do
+  source "#{instance_name}_server.xml"
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, "tomcat_service_systemd[#{instance_name}]"
+end
+
+tomcat_service_systemd instance_name do
+  action [:start, :enable]
+  service_template_source 'my_init_systemd.erb'
+  service_template_cookbook 'test'
+end

--- a/test/cookbooks/test/templates/my_init_systemd.erb
+++ b/test/cookbooks/test/templates/my_init_systemd.erb
@@ -1,0 +1,32 @@
+# Systemd unit file for tomcat_<%= @instance %>
+
+[Unit]
+Description=<%= @instance %> My Apache Tomcat Application
+After=syslog.target network.target
+
+[Service]
+Type=forking
+
+<% @env_vars.each do |h| -%>
+  <% h.each_pair do |k,v| -%>
+Environment="<%= k -%>=<%= v %>"
+  <% end -%>
+<% end -%>
+
+<% @service_vars.each do |h| -%>
+  <% h.each_pair do |k,v| -%>
+<%= k -%>=<%= v %>
+  <% end -%>
+<% end -%>
+
+ExecStart=<%= @install_path %>/bin/catalina.sh start
+ExecStop=<%= @install_path %>/bin/catalina.sh stop
+SuccessExitStatus=0 143
+Restart=on-failure
+RestartSec=2
+
+User=<%= @user %>
+Group=<%= @group %>
+
+[Install]
+WantedBy=multi-user.target

--- a/test/integration/multi_instance/default_spec.rb
+++ b/test/integration/multi_instance/default_spec.rb
@@ -84,3 +84,10 @@ describe service('tomcat_helloworld') do
   it { should be_enabled }
   it { should be_running }
 end
+
+describe service('tomcat_template') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+  its('description') { should cmp 'template My Apache Tomcat Application' }
+end


### PR DESCRIPTION
Make accessible the `template` resources' `source` and `cookbook` properties.
Should also clear up travis by pinning (in the `test` cookbook's `metadata.rb`) to the last version of the `java` cookbook to offer a default recipe rather than resources.

### Description
<!--- Describe what this change achieves -->

### Issues Resolved
#333 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>