### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file is used to list changes made in each version of the tomcat cookbook.
 
 ## Unreleased
 
+- resolved cookstyle error: resources/service_systemd.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/service_upstart.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: test/integration/multi_instance/controls/default_spec.rb:4:14 warning: `InSpec/Deprecations/AttributeHelper`
+- resolved cookstyle error: test/integration/multi_instance/controls/default_spec.rb:5:15 warning: `InSpec/Deprecations/AttributeHelper`
+- resolved cookstyle error: test/integration/multi_instance/controls/default_spec.rb:6:13 warning: `InSpec/Deprecations/AttributeHelper`
 ## 4.2.2 - *2021-08-30*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/resources/service_systemd.rb
+++ b/resources/service_systemd.rb
@@ -18,6 +18,7 @@
 #
 
 provides :tomcat_service_systemd
+unified_mode true
 
 provides :tomcat_service, os: 'linux' do |_node|
   Chef::Platform::ServiceHelpers.service_resource_providers.include?(:systemd)

--- a/resources/service_upstart.rb
+++ b/resources/service_upstart.rb
@@ -18,6 +18,7 @@
 #
 
 provides :tomcat_service_upstart
+unified_mode true
 
 provides :tomcat_service, platform_family: 'debian' do |_node|
   Chef::Platform::ServiceHelpers.service_resource_providers.include?(:upstart) &&

--- a/test/integration/multi_instance/controls/default_spec.rb
+++ b/test/integration/multi_instance/controls/default_spec.rb
@@ -1,9 +1,9 @@
 puts 'Sleeping to make sure the services are started'
 sleep 10
 
-version_10 = attribute('tomcat_version_10').tr('.', '_')
-version_8_5 = attribute('tomcat_version_8_5').tr('.', '_')
-version_7 = attribute('tomcat_version_7').tr('.', '_')
+version_10 = input('tomcat_version_10').tr('.', '_')
+version_8_5 = input('tomcat_version_8_5').tr('.', '_')
+version_7 = input('tomcat_version_7').tr('.', '_')
 
 describe file('/opt/tomcat_symworld_custom') do
   it { should be_symlink }


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.25.6 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with resources/service_systemd.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)

### Issues found and resolved with resources/service_upstart.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)

### Issues found and resolved with test/integration/multi_instance/controls/default_spec.rb

 - 4:14 warning: `InSpec/Deprecations/AttributeHelper` - InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values. (https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper)
 - 5:15 warning: `InSpec/Deprecations/AttributeHelper` - InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values. (https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper)
 - 6:13 warning: `InSpec/Deprecations/AttributeHelper` - InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values. (https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper)