### PR TITLE
chore: migrate to Policyfile

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+name 'tomcat'
+
+run_list 'test::default'
+
+cookbook 'tomcat', path: '.'
+cookbook 'test', path: 'test/cookbooks/test'

--- a/chefignore
+++ b/chefignore
@@ -83,23 +83,11 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*
 Gemfile
 Gemfile.lock
-
-# Policyfile #
-##############
-Policyfile.rb
-Policyfile.lock.json
 
 # Documentation #
 #############

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 require_relative '../libraries/install_helpers'
 


### PR DESCRIPTION
## Summary

* add `Policyfile.rb` for `test::default`
* remove `Berksfile`
* switch ChefSpec from Berkshelf to Policyfile support
* stop excluding Berkshelf and Policyfile files from cookbook packaging

## Local verification

* `chef install Policyfile.rb`
* `cookstyle --no-server --cache-root /private/tmp/rubocop_cache`
* `/opt/homebrew/bin/markdownlint-cli2 "**/*.md"`
* `env GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec`
* `git diff --check`
* `kitchen list`
* `env KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list`
